### PR TITLE
Avoid updates clobbering dump cache

### DIFF
--- a/dump/pom.xml
+++ b/dump/pom.xml
@@ -8,7 +8,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20220530.1</version>
+      <version>1.20220919.1</version>
    </parent>
 
    <dependencies>

--- a/dump/src/util/dump/Dump.java
+++ b/dump/src/util/dump/Dump.java
@@ -50,15 +50,15 @@ import org.slf4j.LoggerFactory;
 import gnu.trove.list.TByteList;
 import gnu.trove.list.array.TByteArrayList;
 import gnu.trove.set.hash.TLongHashSet;
-import util.dump.cache.SoftLRUCache;
 import util.dump.ExternalizableBean.externalizationVersion;
 import util.dump.UniqueIndex.DuplicateKeyException;
+import util.dump.cache.SoftLRUCache;
+import util.dump.io.IOUtils;
 import util.dump.sort.InfiniteSorter;
 import util.dump.stream.AesCrypter;
 import util.dump.stream.Compression;
 import util.dump.stream.ObjectStreamProvider;
 import util.dump.stream.SingleTypeObjectStreamProvider;
-import util.dump.io.IOUtils;
 import util.dump.time.StopWatch;
 
 
@@ -773,7 +773,7 @@ public class Dump<E> implements DumpInput<E> {
                   for ( DumpIndex<E> index : _indexes ) {
                      index.update(pos, oldItem, newItem);
                   }
-                  if ( _cache != null ) {
+                  if ( _cache != null && _cache.containsKey(pos) ) {
                      _cache.put(pos, newBytes);
                   }
                   return oldItem;

--- a/dumpsearch/pom.xml
+++ b/dumpsearch/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20220530.1</version>
+      <version>1.20220919.1</version>
    </parent>
 
    <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <groupId>mkr</groupId>
    <artifactId>dump-pom</artifactId>
    <name>mkr dump pom</name>
-   <version>1.20220530.1</version>
+   <version>1.20220919.1</version>
    <packaging>pom</packaging>
 
    <modules>


### PR DESCRIPTION
Replace only preexisting items during updates, avoid putting items there which are irrelevant to readers. Attempt to increase cache hit rate, i.e. in the presence of background tasks.