### PR TITLE
Dump inconsistency auto-repair

### DIFF
--- a/dump/pom.xml
+++ b/dump/pom.xml
@@ -8,7 +8,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20221024.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <dependencies>

--- a/dump/src/util/dump/DumpIndex.java
+++ b/dump/src/util/dump/DumpIndex.java
@@ -301,7 +301,13 @@ public abstract class DumpIndex<E> implements Closeable {
          // rebuild index if it is not current
          initFromDump();
       } else {
-         load();
+         try {
+            load();
+         } catch (RuntimeException e) {
+            LOG.warn("Failed to load index, will delete and init from dump", e);
+            deleteAllIndexFiles();
+            initFromDump();
+         }
       }
    }
 

--- a/dump/src/util/dump/DumpIndex.java
+++ b/dump/src/util/dump/DumpIndex.java
@@ -282,6 +282,10 @@ public abstract class DumpIndex<E> implements Closeable {
     * create or open index
     */
    protected void createOrLoad() {
+      createOrLoad(true);
+   }
+
+   private void createOrLoad( boolean retry ) {
 
       boolean indexInvalid = !_lookupFile.exists() || (_lookupFile.length() == 0 && _lookupFile.isFile()) || !checkMeta();
       if ( indexInvalid ) {
@@ -303,10 +307,15 @@ public abstract class DumpIndex<E> implements Closeable {
       } else {
          try {
             load();
-         } catch (RuntimeException e) {
+         }
+         catch ( RuntimeException e ) {
             LOG.warn("Failed to load index, will delete and init from dump", e);
-            deleteAllIndexFiles();
-            initFromDump();
+            if ( retry ) {
+               deleteAllIndexFiles();
+               createOrLoad(false);
+            } else {
+               throw e;
+            }
          }
       }
    }

--- a/dumpsearch/pom.xml
+++ b/dumpsearch/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20221024.1</version>
+      <version>1.20230306.1</version>
    </parent>
 
    <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <groupId>mkr</groupId>
    <artifactId>dump-pom</artifactId>
    <name>mkr dump pom</name>
-   <version>1.20221024.1</version>
+   <version>1.20230306.1</version>
    <packaging>pom</packaging>
 
    <modules>


### PR DESCRIPTION
More fine-grained error handling, allows to recreate just the affected index instead of the whole dump, if the latter is still consistent.