### PR TITLE
Provide option to rewrite dump in case of version mismatch

### DIFF
--- a/dump/src/util/dump/Dump.java
+++ b/dump/src/util/dump/Dump.java
@@ -1207,12 +1207,7 @@ public class Dump<E> implements DumpInput<E> {
    }
 
    private void setExternalizationVersionInMetaData() {
-      externalizationVersion version = _beanClass.getAnnotation(externalizationVersion.class);
-      if ( version != null ) {
-         _metaData.put("externalizationVersion", "" + version.version());
-      } else {
-         _metaData.remove("externalizationVersion");
-      }
+      _metaData.put("externalizationVersion", "" + getVersionFromCode());
    }
 
    /**

--- a/dump/src/util/dump/Dump.java
+++ b/dump/src/util/dump/Dump.java
@@ -1088,7 +1088,7 @@ public class Dump<E> implements DumpInput<E> {
 
          String dumpVersionString = _metaData.get("externalizationVersion");
          int dumpVersion = dumpVersionString == null ? 0 : Integer.parseInt(dumpVersionString);
-         if ( dumpVersion != newVersion ) {
+         if ( dumpVersion != newVersion && _dumpFile.exists() ) {
             switch ( version.onIncompatibleVersion() ) {
             case RenameDump: {
                _log.warn("externalizationVersion in dump {} does not match current version {}, will rename old dump files", dumpVersion, newVersion);

--- a/dump/src/util/dump/Dump.java
+++ b/dump/src/util/dump/Dump.java
@@ -1102,6 +1102,12 @@ public class Dump<E> implements DumpInput<E> {
                deleteFile(_deletionsFile);
                break;
             }
+            case RewriteDump: {
+               StopWatch t = new StopWatch();
+               _log.warn("externalizationVersion in dump {} does not match current version {}, will rewrite dump files", dumpVersion, newVersion);
+               prune();
+               _log.info("...rewrote dump {} in {}", _dumpFile, t);
+            }
             }
          }
 

--- a/dump/src/util/dump/Dump.java
+++ b/dump/src/util/dump/Dump.java
@@ -1202,7 +1202,7 @@ public class Dump<E> implements DumpInput<E> {
    }
 
    private void resetMeta() {
-      _sequence = (long)(Math.random() * 1000000);
+      _sequence++;
       _metaData.clear();
    }
 

--- a/dump/src/util/dump/ExternalizableBean.java
+++ b/dump/src/util/dump/ExternalizableBean.java
@@ -1259,7 +1259,8 @@ public interface ExternalizableBean extends Externalizable {
 
    enum OnIncompatibleVersion {
       DeleteDump,
-      RenameDump
+      RenameDump,
+      RewriteDump
    }
 
 }

--- a/dump/test/util/dump/DumpTest.java
+++ b/dump/test/util/dump/DumpTest.java
@@ -120,7 +120,7 @@ public class DumpTest {
       File dumpFile = new File("DumpTest.dmp");
       try (Dump<Bean> dump = new Dump<>(Bean.class, dumpFile)) {
          for ( Bean bean : dump ) {
-            Assert.assertTrue("Element returned during iteration of empty dump", false);
+            Assert.fail("Element returned during iteration of empty dump");
             Assert.assertNotNull("Element returned during iteration of empty dump", bean);
          }
       }
@@ -381,7 +381,8 @@ public class DumpTest {
       for ( BeanVersion5 b : v5Dump ) {
          n++;
       }
-      assertThat(n).as("Dump was not rewritten after version upgrade").isEqualTo(1);
+      assertThat(n).as("Dump did not retain contents during version upgrade").isEqualTo(1);
+      assertThat(v5Dump.getMetaValue("externalizationVersion")).as("Dump was not rewritten after version upgrade").isEqualTo("5");
       v5Dump.close();
    }
 

--- a/dump/test/util/dump/DumpTest.java
+++ b/dump/test/util/dump/DumpTest.java
@@ -385,6 +385,35 @@ public class DumpTest {
       v5Dump.close();
    }
 
+   @Test
+   public void testVersionUpdateWithoutPreexistingFiles() throws Exception {
+      File dumpFile = new File("DumpTest.dmp");
+      Dump<Bean> dump = new Dump<>(Bean.class, dumpFile);
+      dump.close();
+      dumpFile.delete();
+
+      Dump<BeanVersion2> v2Dump = new Dump<>(BeanVersion2.class, dumpFile);
+      File oldDumpFile = new File("DumpTest.dmp.version0");
+      assertThat(oldDumpFile).as("Dump was renamed after version upgrade on nonexistent file").doesNotExist();
+      v2Dump.add(new BeanVersion2(1));
+      v2Dump.close();
+      dumpFile.delete();
+
+      Dump<BeanVersion3> v3Dump = new Dump<>(BeanVersion3.class, dumpFile);
+      oldDumpFile = new File("DumpTest.dmp.version2");
+      assertThat(oldDumpFile).as("Dump was renamed after version upgrade on nonexistent file").doesNotExist();
+      v3Dump.close();
+      dumpFile.delete();
+
+      Dump<BeanVersion4> v4Dump = new Dump<>(BeanVersion4.class, dumpFile);
+      v4Dump.close();
+      dumpFile.delete();
+
+      Dump<BeanVersion5> v5Dump = new Dump<>(BeanVersion5.class, dumpFile);
+      v5Dump.close();
+      dumpFile.delete();
+   }
+
    public static class Bean implements ExternalizableBean {
 
       @externalize(1)

--- a/dump/test/util/dump/DumpTest.java
+++ b/dump/test/util/dump/DumpTest.java
@@ -2,6 +2,7 @@ package util.dump;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static util.dump.ExternalizableBean.OnIncompatibleVersion.DeleteDump;
+import static util.dump.ExternalizableBean.OnIncompatibleVersion.RewriteDump;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -372,7 +373,16 @@ public class DumpTest {
          n++;
       }
       assertThat(n).as("Dump was not deleted after version upgrade").isEqualTo(0);
+      v4Dump.add(new BeanVersion4(1));
       v4Dump.close();
+
+      Dump<BeanVersion5> v5Dump = new Dump<>(BeanVersion5.class, dumpFile);
+      n = 0;
+      for ( BeanVersion5 b : v5Dump ) {
+         n++;
+      }
+      assertThat(n).as("Dump was not rewritten after version upgrade").isEqualTo(1);
+      v5Dump.close();
    }
 
    public static class Bean implements ExternalizableBean {
@@ -425,6 +435,20 @@ public class DumpTest {
       public BeanVersion4() {}
 
       public BeanVersion4( int id ) {
+         _id = id;
+      }
+   }
+
+
+   @externalizationVersion(version = 5, onIncompatibleVersion = RewriteDump)
+   public static class BeanVersion5 implements ExternalizableBean {
+
+      @externalize(1)
+      int _id;
+
+      public BeanVersion5() {}
+
+      public BeanVersion5( int id ) {
          _id = id;
       }
    }


### PR DESCRIPTION
Our usual schema migration pattern consists of incremental (bidirectionally compatible) changes, which break compatibility only if more than one step is taken at the same time. Previous options were to rename or delete the existing dump, leaving us with a new but empty dump initially.

OnIncompatibleVersion.RewriteDump ensures the schema migration to take place without any burden on the higher layers of the application.