### PR TITLE
DumpIndex: reset lookup maps before retrying failed initialization

### DIFF
--- a/dump/src/util/dump/Dump.java
+++ b/dump/src/util/dump/Dump.java
@@ -467,7 +467,7 @@ public class Dump<E> implements DumpInput<E> {
     */
    public void flush() throws IOException {
       _outputStream.flush();
-      _outputStreamChannel.force(false);
+      _outputStreamChannel.force(true);
       for ( DumpIndex<E> index : new ArrayList<>(_indexes) ) {
          index.flush();
       }
@@ -482,7 +482,7 @@ public class Dump<E> implements DumpInput<E> {
    public void flushMeta() throws IOException {
       if ( _deletionsOutput != null ) {
          _deletionsOutput.flush();
-         _deletionsOutputChannel.force(false);
+         _deletionsOutputChannel.force(true);
       }
       writeMeta();
       for ( DumpIndex<E> index : new ArrayList<>(_indexes) ) {
@@ -1066,7 +1066,7 @@ public class Dump<E> implements DumpInput<E> {
          getMetaRAF().writeUTF(e.getKey());
          getMetaRAF().writeUTF(e.getValue());
       }
-      getMetaRAF().getChannel().force(false);
+      getMetaRAF().getChannel().force(true);
    }
 
    private void appendNextItemPos( byte[] bytes, byte[] nextItemPos ) {

--- a/dump/src/util/dump/DumpIndex.java
+++ b/dump/src/util/dump/DumpIndex.java
@@ -312,6 +312,7 @@ public abstract class DumpIndex<E> implements Closeable {
             LOG.warn("Failed to load index, will delete and init from dump", e);
             if ( retry ) {
                deleteAllIndexFiles();
+               initLookupMap();
                createOrLoad(false);
             } else {
                throw e;

--- a/dump/src/util/dump/DumpIndex.java
+++ b/dump/src/util/dump/DumpIndex.java
@@ -136,6 +136,7 @@ public abstract class DumpIndex<E> implements Closeable {
 
    private final File             _updatesFile;
    private       DataOutputStream _updatesOutput;
+   protected     FileChannel      _updatesOutputStreamChannel;
 
    /**
     * Creates an index and adds it to the {@link Dump}.
@@ -231,6 +232,10 @@ public abstract class DumpIndex<E> implements Closeable {
       if ( _lookupOutputStream != null ) {
          _lookupOutputStream.flush();
          _lookupOutputStreamChannel.force(false);
+      }
+      if ( _updatesOutput != null ) {
+         _updatesOutput.flush();
+         _updatesOutputStreamChannel.force(false);
       }
    }
 
@@ -401,7 +406,9 @@ public abstract class DumpIndex<E> implements Closeable {
       synchronized ( _dump ) {
          if ( _updatesOutput == null ) {
             try {
-               _updatesOutput = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(_updatesFile, true), DumpWriter.DEFAULT_BUFFER_SIZE));
+               FileOutputStream fileOutputStream = new FileOutputStream(_updatesFile, true);
+               _updatesOutputStreamChannel = fileOutputStream.getChannel();
+               _updatesOutput = new DataOutputStream(new BufferedOutputStream(fileOutputStream, DumpWriter.DEFAULT_BUFFER_SIZE));
             }
             catch ( IOException argh ) {
                throw new RuntimeException("Failed to init updates outputstream " + _updatesFile, argh);

--- a/dump/src/util/dump/DumpIndex.java
+++ b/dump/src/util/dump/DumpIndex.java
@@ -25,12 +25,12 @@ import org.slf4j.LoggerFactory;
 
 import gnu.trove.list.TLongList;
 import util.dump.Dump.DumpAccessFlag;
-import util.dump.stream.ExternalizableObjectOutputStream;
-import util.dump.stream.SingleTypeObjectOutputStream;
 import util.dump.io.IOUtils;
 import util.dump.reflection.FieldAccessor;
 import util.dump.reflection.FieldFieldAccessor;
 import util.dump.reflection.Reflection;
+import util.dump.stream.ExternalizableObjectOutputStream;
+import util.dump.stream.SingleTypeObjectOutputStream;
 
 
 /**
@@ -139,7 +139,8 @@ public abstract class DumpIndex<E> implements Closeable {
 
    /**
     * Creates an index and adds it to the {@link Dump}.
-    * @param dump the parent dump to add this index to
+    *
+    * @param dump          the parent dump to add this index to
     * @param fieldAccessor the accessor to the field containing the index key
     */
    public DumpIndex( Dump<E> dump, FieldAccessor fieldAccessor ) {

--- a/dump/src/util/dump/DumpIndex.java
+++ b/dump/src/util/dump/DumpIndex.java
@@ -231,11 +231,11 @@ public abstract class DumpIndex<E> implements Closeable {
    public void flush() throws IOException {
       if ( _lookupOutputStream != null ) {
          _lookupOutputStream.flush();
-         _lookupOutputStreamChannel.force(false);
+         _lookupOutputStreamChannel.force(true);
       }
       if ( _updatesOutput != null ) {
          _updatesOutput.flush();
-         _updatesOutputStreamChannel.force(false);
+         _updatesOutputStreamChannel.force(true);
       }
    }
 
@@ -504,7 +504,7 @@ public abstract class DumpIndex<E> implements Closeable {
       metaRAF.writeUTF(_dump._beanClass.getName());
       metaRAF.writeUTF(getIndexType());
       metaRAF.setLength(metaRAF.getFilePointer());
-      metaRAF.getChannel().force(false);
+      metaRAF.getChannel().force(true);
    }
 
    abstract void add( E o, long pos );


### PR DESCRIPTION
When retrying the initialization, we should start with a clean slate.