### PR TITLE
Improve UniqueIndex load() performance

### DIFF
--- a/dump/src/util/dump/DumpIndex.java
+++ b/dump/src/util/dump/DumpIndex.java
@@ -312,6 +312,7 @@ public abstract class DumpIndex<E> implements Closeable {
             LOG.warn("Failed to load index, will delete and init from dump", e);
             if ( retry ) {
                deleteAllIndexFiles();
+               initLookupMap();
                createOrLoad(false);
             } else {
                throw e;

--- a/dump/src/util/dump/DumpIndex.java
+++ b/dump/src/util/dump/DumpIndex.java
@@ -125,7 +125,7 @@ public abstract class DumpIndex<E> implements Closeable {
    private final   File             _metaFile;
    private         RandomAccessFile _metaRaf;
    protected       DataOutputStream _lookupOutputStream;
-   private         FileChannel      _lookupOutputStreamChannel;
+   protected       FileChannel      _lookupOutputStreamChannel;
    protected final FieldAccessor    _fieldAccessor;
    protected final boolean          _fieldIsInt;
    protected final boolean          _fieldIsIntObject;

--- a/dump/src/util/dump/DumpIndex.java
+++ b/dump/src/util/dump/DumpIndex.java
@@ -136,6 +136,7 @@ public abstract class DumpIndex<E> implements Closeable {
 
    private final File             _updatesFile;
    private       DataOutputStream _updatesOutput;
+   protected     FileChannel      _updatesOutputStreamChannel;
 
    /**
     * Creates an index and adds it to the {@link Dump}.
@@ -231,6 +232,10 @@ public abstract class DumpIndex<E> implements Closeable {
       if ( _lookupOutputStream != null ) {
          _lookupOutputStream.flush();
          _lookupOutputStreamChannel.force(false);
+      }
+      if ( _updatesOutput != null ) {
+         _updatesOutput.flush();
+         _updatesOutputStreamChannel.force(false);
       }
    }
 
@@ -401,7 +406,9 @@ public abstract class DumpIndex<E> implements Closeable {
       synchronized ( _dump ) {
          if ( _updatesOutput == null ) {
             try {
-               _updatesOutput = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(_updatesFile, true), DumpWriter.DEFAULT_BUFFER_SIZE));
+               FileOutputStream fileOutputStream = new FileOutputStream(_updatesFile, true);
+               _updatesOutputStreamChannel = fileOutputStream.getChannel();
+               _updatesOutput = new DataOutputStream(new BufferedOutputStream(fileOutputStream, DumpWriter.DEFAULT_BUFFER_SIZE));
             }
             catch ( IOException argh ) {
                throw new RuntimeException("Failed to init updates outputstream " + _updatesFile, argh);

--- a/dump/src/util/dump/DumpIndex.java
+++ b/dump/src/util/dump/DumpIndex.java
@@ -25,12 +25,12 @@ import org.slf4j.LoggerFactory;
 
 import gnu.trove.list.TLongList;
 import util.dump.Dump.DumpAccessFlag;
-import util.dump.stream.ExternalizableObjectOutputStream;
-import util.dump.stream.SingleTypeObjectOutputStream;
 import util.dump.io.IOUtils;
 import util.dump.reflection.FieldAccessor;
 import util.dump.reflection.FieldFieldAccessor;
 import util.dump.reflection.Reflection;
+import util.dump.stream.ExternalizableObjectOutputStream;
+import util.dump.stream.SingleTypeObjectOutputStream;
 
 
 /**
@@ -139,7 +139,8 @@ public abstract class DumpIndex<E> implements Closeable {
 
    /**
     * Creates an index and adds it to the {@link Dump}.
-    * @param dump the parent dump to add this index to
+    *
+    * @param dump          the parent dump to add this index to
     * @param fieldAccessor the accessor to the field containing the index key
     */
    public DumpIndex( Dump<E> dump, FieldAccessor fieldAccessor ) {

--- a/dump/src/util/dump/MmappedUniqueIndex.java
+++ b/dump/src/util/dump/MmappedUniqueIndex.java
@@ -1,0 +1,406 @@
+package util.dump;
+
+import java.io.EOFException;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+
+import javax.annotation.Nullable;
+
+import gnu.trove.map.TLongIntMap;
+import gnu.trove.map.hash.TLongIntHashMap;
+import util.dump.reflection.FieldAccessor;
+
+
+/**
+ * Uses memory-mapped buffers for reading file contents almost instantaneously.
+ * <p>
+ * Initially limited to lookup and updates file sizes < 2 GiB.
+ * <p>
+ * Initially limited to int / Integer and long / Long field types.
+ */
+public class MmappedUniqueIndex<E> extends UniqueIndex<E> {
+
+   public static final String           UNSUPPORTED_TYPE = "Initially limited to int / Integer and long / Long field types.";
+   private             RandomAccessFile _lookupOutputRaf;
+   private             MappedByteBuffer _lookupOutputMappedByteBuffer;
+   private             RandomAccessFile _updatesOutputRaf;
+   private             MappedByteBuffer _updatesOutputMappedByteBuffer;
+
+   public MmappedUniqueIndex( Dump<E> dump, FieldAccessor fieldAccessor ) {
+      super(dump, fieldAccessor);
+   }
+
+   public MmappedUniqueIndex( Dump<E> dump, String fieldName ) throws NoSuchFieldException {
+      super(dump, fieldName);
+   }
+
+   @Override
+   public void add( E o, long pos ) {
+      try {
+         if ( _fieldIsInt ) {
+            int key = getIntKey(o);
+            if ( _lookupInt.containsKey(key) ) {
+               throw new DuplicateKeyException("Dump already contains an instance with the key " + key);
+            }
+            _lookupInt.put(key, pos);
+            getLookupBuffer().putInt(key);
+         } else if ( _fieldIsLong ) {
+            long key = getLongKey(o);
+            if ( _lookupLong.containsKey(key) ) {
+               throw new DuplicateKeyException("Dump already contains an instance with the key " + key);
+            }
+            _lookupLong.put(key, pos);
+            getLookupBuffer().putLong(key);
+         }
+         getLookupBuffer().putLong(pos);
+
+         if ( isCompactLookupNeeded() ) {
+            compactLookup();
+         }
+      }
+      catch ( BufferOverflowException argh ) {
+         throw new RuntimeException("Failed to add key to index " + getLookupFile(), argh);
+      }
+   }
+
+   @Override
+   public void close() throws IOException {
+      closeLookupOutputBuffer();
+      closeUpdatesOutputBuffer();
+
+      super.close();
+   }
+
+   @Override
+   public void flush() throws IOException {
+      // flushBuffer(_lookupOutputMappedByteBuffer, _lookupOutputStreamChannel);
+      // flushBuffer(_updatesOutputMappedByteBuffer, _updatesOutputStreamChannel);
+   }
+
+   @Override
+   protected void addToIgnoredPositions( long pos ) {
+      try {
+         // we add this position to the stream of ignored positions used during load()
+         getUpdatesBuffer().putLong(pos);
+      }
+      catch ( BufferOverflowException argh ) {
+         throw new RuntimeException("Failed to append to updates file " + getUpdatesFile(), argh);
+      }
+   }
+
+   @Override
+   protected void init() {
+      if ( !_fieldIsInt && !_fieldIsLong ) {
+         throw new IllegalArgumentException(UNSUPPORTED_TYPE);
+      }
+      super.init();
+   }
+
+   @Override
+   protected void initLookupOutputStream() {
+      try {
+         _lookupOutputRaf = new RandomAccessFile(getLookupFile(), "rw");
+         _lookupOutputStreamChannel = _lookupOutputRaf.getChannel();
+      }
+      catch ( IOException argh ) {
+         throw new RuntimeException("Failed to initialize dump index with lookup file " + getLookupFile(), argh);
+      }
+   }
+
+   protected void initUpdatesOutputStream() {
+      try {
+         _updatesOutputRaf = new RandomAccessFile(getUpdatesFile(), "rw");
+         _updatesOutputStreamChannel = _updatesOutputRaf.getChannel();
+      }
+      catch ( IOException argh ) {
+         throw new RuntimeException("Failed to initialize dump index with lookup file " + getLookupFile(), argh);
+      }
+   }
+
+   @Override
+   protected void load() {
+      if ( !getLookupFile().exists() || getLookupFile().length() == 0 ) {
+         return;
+      }
+
+      final TLongIntMap positionsToIgnore;
+      if ( getUpdatesFile().exists() ) {
+         if ( getUpdatesFile().length() % 8 != 0 ) {
+            throw new RuntimeException("Index corrupted: " + getUpdatesFile() + " has unbalanced size.");
+         }
+         positionsToIgnore = new TLongIntHashMap((int)(getUpdatesFile().length() / 8));
+         try (FileInputStream fileInputStream = new FileInputStream(getUpdatesFile())) {
+            try (FileChannel channel = fileInputStream.getChannel()) {
+               MappedByteBuffer buffer = channel.map(MapMode.READ_ONLY, 0, channel.size());
+               long pos;
+               while ( (pos = readNextPosition(buffer)) != -1 ) {
+                  positionsToIgnore.adjustOrPutValue(pos, 1, 1);
+               }
+            }
+         }
+         catch ( IOException argh ) {
+            // since we do a _updatesFile.exists() this is most unlikely
+            throw new RuntimeException("Failed read updates from " + getUpdatesFile(), argh);
+         }
+      } else {
+         positionsToIgnore = new TLongIntHashMap();
+      }
+
+      boolean mayEOF = true;
+      final int size = getHeadroomForLoad(getLookupSizeFromFiles());
+      initLookupMap(size);
+      if ( _fieldIsInt ) {
+         FileChannel in = null;
+         try {
+            in = new FileInputStream(getLookupFile()).getChannel();
+            MappedByteBuffer buffer = in.map(MapMode.READ_ONLY, 0, in.size());
+
+            while ( true ) {
+               Object payload = readPayload(buffer);
+               if ( payload != null ) {
+                  mayEOF = false;
+               }
+               int key = buffer.getInt();
+               mayEOF = false;
+               long pos = buffer.getLong();
+               mayEOF = true;
+               if ( positionsToIgnore.get(pos) > 0 ) {
+                  positionsToIgnore.adjustValue(pos, -1);
+                  continue;
+               }
+               if ( !_dump._deletedPositions.contains(pos) ) {
+                  long previousEntry = _lookupInt.put(key, pos);
+                  if ( previousEntry != _noEntry ) {
+                     _lookupInt.put(key, previousEntry);
+                     throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
+                  }
+                  cachePayload(pos, payload);
+               }
+            }
+         }
+         catch ( BufferUnderflowException | EOFException argh ) {
+            if ( !mayEOF ) {
+               throw new RuntimeException("Failed to read lookup from " + getLookupFile() + ", file is unbalanced - unexpected EoF", argh);
+            }
+         }
+         catch ( IOException argh ) {
+            throw new RuntimeException("Failed to read lookup from " + getLookupFile(), argh);
+         }
+         finally {
+            if ( in != null ) {
+               try {
+                  in.close();
+               }
+               catch ( IOException argh ) {
+                  throw new RuntimeException("Failed to close input stream.", argh);
+               }
+            }
+         }
+      } else if ( _fieldIsLong ) {
+         FileChannel in = null;
+         try {
+            in = new FileInputStream(getLookupFile()).getChannel();
+            MappedByteBuffer buffer = in.map(MapMode.READ_ONLY, 0, in.size());
+
+            while ( true ) {
+               Object payload = readPayload(buffer);
+               if ( payload != null ) {
+                  mayEOF = false;
+               }
+               long key = buffer.getLong();
+               mayEOF = false;
+               long pos = buffer.getLong();
+               mayEOF = true;
+               if ( positionsToIgnore.get(pos) > 0 ) {
+                  positionsToIgnore.adjustValue(pos, -1);
+                  continue;
+               }
+               if ( !_dump._deletedPositions.contains(pos) ) {
+                  long previousEntry = _lookupLong.put(key, pos);
+                  if ( previousEntry != _noEntry ) {
+                     _lookupLong.put(key, previousEntry);
+                     throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
+                  }
+                  cachePayload(pos, payload);
+               }
+            }
+         }
+         catch ( BufferUnderflowException | EOFException argh ) {
+            if ( !mayEOF ) {
+               throw new RuntimeException("Failed to read lookup from " + getLookupFile() + ", file is unbalanced - unexpected EoF", argh);
+            }
+         }
+         catch ( IOException argh ) {
+            throw new RuntimeException("Failed to read lookup from " + getLookupFile(), argh);
+         }
+         finally {
+            if ( in != null ) {
+               try {
+                  in.close();
+               }
+               catch ( IOException argh ) {
+                  throw new RuntimeException("Failed to close input stream.", argh);
+               }
+            }
+         }
+      }
+   }
+
+   protected long readNextPosition( MappedByteBuffer updatesInput ) {
+      if ( updatesInput == null ) {
+         return -1;
+      }
+      if ( updatesInput.remaining() < 8 ) {
+         return -1;
+      }
+
+      try {
+         return updatesInput.getLong();
+      }
+      catch ( BufferUnderflowException argh ) {
+         return -1;
+      }
+   }
+
+   protected Object readPayload( MappedByteBuffer in ) {
+      return null;
+   }
+
+   @Override
+   void delete( E o, long pos ) {
+      if ( _fieldIsInt ) {
+         int key = getIntKey(o);
+         long p = _lookupInt.remove(key);
+         if ( p != pos ) {
+            _lookupInt.put(key, p);
+            throw new DuplicateKeyException("Dump apparently contains two instances with the key " + key + " at positions " + p + " and " + pos);
+         }
+      } else if ( _fieldIsLong ) {
+         long key = getLongKey(o);
+         long p = _lookupLong.remove(key);
+         if ( p != pos ) {
+            _lookupLong.put(key, p);
+            throw new DuplicateKeyException("Dump apparently contains two instances with the key " + key + " at positions " + p + " and " + pos);
+         }
+      }
+   }
+
+   private void closeBuffer( @Nullable MappedByteBuffer buffer, FileChannel channel ) throws IOException {
+      if ( buffer != null ) {
+         flushBuffer(buffer, channel);
+         channel.truncate(getUsedSize(channel, buffer));
+         channel.close();
+      }
+   }
+
+   private void closeLookupOutputBuffer() throws IOException {
+      closeBuffer(_lookupOutputMappedByteBuffer, _lookupOutputStreamChannel);
+      _lookupOutputMappedByteBuffer = null;
+      if ( _lookupOutputRaf != null ) {
+         _lookupOutputRaf.close();
+      }
+   }
+
+   private void closeUpdatesOutputBuffer() throws IOException {
+      closeBuffer(_updatesOutputMappedByteBuffer, _updatesOutputStreamChannel);
+      _updatesOutputMappedByteBuffer = null;
+      if ( _updatesOutputRaf != null ) {
+         _updatesOutputRaf.close();
+      }
+   }
+
+   private void flushBuffer( @Nullable MappedByteBuffer buffer, FileChannel channel ) throws IOException {
+      if ( buffer != null ) {
+         buffer.force(0, buffer.position());
+         channel.force(false);
+      }
+   }
+
+   /**
+    * Defines the number of key-value mappings or positions we should reserve when mapping the output buffers.
+    */
+   private long getAppendElementCount() {
+      return 4 * 1024 * 1024;
+   }
+
+   /**
+    * Defines the size of each key-value mapping we should reserve when mapping the output buffer.
+    */
+   private long getAppendMappingSize() {
+      if ( _fieldIsInt ) {
+         return getAppendPositionSize() + 4;  // size of primitive int
+      }
+      if ( _fieldIsLong ) {
+         return getAppendPositionSize() + 8;  // size of primitive long
+      }
+      throw new IllegalArgumentException(UNSUPPORTED_TYPE);
+   }
+
+   /**
+    * Defines the size of each position entry we should reserve when mapping the output buffer.
+    */
+   private long getAppendPositionSize() {
+      return 8;  // size of primitive long
+   }
+
+   private MappedByteBuffer getLookupBuffer() {
+      synchronized ( this ) {
+         if ( _lookupOutputMappedByteBuffer == null || _lookupOutputMappedByteBuffer.remaining() < getAppendMappingSize() ) {
+            remapLookupOutputBuffer();
+         }
+         return _lookupOutputMappedByteBuffer;
+      }
+   }
+
+   private MappedByteBuffer getUpdatesBuffer() {
+      synchronized ( this ) {
+         if ( _updatesOutputStreamChannel == null ) {
+            initUpdatesOutputStream();
+         }
+
+         if ( _updatesOutputMappedByteBuffer == null || _updatesOutputMappedByteBuffer.remaining() < getAppendPositionSize() ) {
+            remapUpdatesOutputBuffer();
+         }
+         return _updatesOutputMappedByteBuffer;
+      }
+   }
+
+   private long getUsedSize( FileChannel channel, MappedByteBuffer buffer ) throws IOException {
+      long unusedOversize = buffer == null ? 0 : buffer.remaining();
+      return channel.size() - unusedOversize;
+   }
+
+   private MappedByteBuffer remapBuffer( FileChannel channel, @Nullable MappedByteBuffer buffer, long freeSize ) throws IOException {
+      flushBuffer(buffer, channel);
+      long usedSize = getUsedSize(channel, buffer);
+      return channel.map(MapMode.READ_WRITE, usedSize, freeSize);
+   }
+
+   private synchronized void remapLookupOutputBuffer() {
+      try {
+         _lookupOutputMappedByteBuffer = remapBuffer(_lookupOutputStreamChannel, _lookupOutputMappedByteBuffer,
+               getAppendElementCount() * getAppendMappingSize());
+      }
+      catch ( IOException argh ) {
+         _lookupOutputMappedByteBuffer = null;
+         throw new RuntimeException("Failed to initialize dump index with lookup file " + getLookupFile(), argh);
+      }
+   }
+
+   private synchronized void remapUpdatesOutputBuffer() {
+      try {
+         _updatesOutputMappedByteBuffer = remapBuffer(_updatesOutputStreamChannel, _updatesOutputMappedByteBuffer,
+               getAppendElementCount() * getAppendPositionSize());
+      }
+      catch ( IOException argh ) {
+         _updatesOutputMappedByteBuffer = null;
+         throw new RuntimeException("Failed to init updates output buffer " + getUpdatesFile(), argh);
+      }
+   }
+}

--- a/dump/src/util/dump/UniqueIndex.java
+++ b/dump/src/util/dump/UniqueIndex.java
@@ -412,12 +412,13 @@ public class UniqueIndex<E> extends DumpIndex<E> {
       }
 
       DataInputStream updatesInput = null;
-      TLongIntMap positionsToIgnore = new TLongIntHashMap();
+      final TLongIntMap positionsToIgnore;
       try {
          if ( getUpdatesFile().exists() ) {
             if ( getUpdatesFile().length() % 8 != 0 ) {
                throw new RuntimeException("Index corrupted: " + getUpdatesFile() + " has unbalanced size.");
             }
+            positionsToIgnore = new TLongIntHashMap((int)(getUpdatesFile().length() / 8));
             try {
                updatesInput = new DataInputStream(new BufferedInputStream(new FileInputStream(getUpdatesFile()), DumpReader.DEFAULT_BUFFER_SIZE));
                long pos;
@@ -429,6 +430,8 @@ public class UniqueIndex<E> extends DumpIndex<E> {
                // since we do a _updatesFile.exists() this is most unlikely
                throw new RuntimeException("Failed read updates from " + getUpdatesFile(), argh);
             }
+         } else {
+            positionsToIgnore = new TLongIntHashMap();
          }
       }
       finally {

--- a/dump/src/util/dump/UniqueIndex.java
+++ b/dump/src/util/dump/UniqueIndex.java
@@ -430,198 +430,6 @@ public class UniqueIndex<E> extends DumpIndex<E> {
                throw new RuntimeException("Failed read updates from " + getUpdatesFile(), argh);
             }
          }
-
-         boolean mayEOF = true;
-         final int size = getHeadroomForLoad(getLookupSizeFromFiles());
-         initLookupMap(size);
-         if ( _fieldIsInt ) {
-            DataInputStream in = null;
-            try {
-               in = new DataInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
-               while ( true ) {
-                  Object payload = readPayload(in);
-                  if ( payload != null ) {
-                     mayEOF = false;
-                  }
-                  int key = in.readInt();
-                  mayEOF = false;
-                  long pos = in.readLong();
-                  mayEOF = true;
-                  if ( positionsToIgnore.get(pos) > 0 ) {
-                     positionsToIgnore.adjustValue(pos, -1);
-                     continue;
-                  }
-                  if ( !_dump._deletedPositions.contains(pos) ) {
-                     long previousEntry = _lookupInt.put(key, pos);
-                     if ( previousEntry != _noEntry ) {
-                        _lookupInt.put(key, previousEntry);
-                        throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
-                     }
-                     cachePayload(pos, payload);
-                  }
-               }
-            }
-            catch ( EOFException argh ) {
-               if ( !mayEOF ) {
-                  throw new RuntimeException("Failed to read lookup from " + getLookupFile() + ", file is unbalanced - unexpected EoF", argh);
-               }
-            }
-            catch ( IOException argh ) {
-               throw new RuntimeException("Failed to read lookup from " + getLookupFile(), argh);
-            }
-            finally {
-               if ( in != null ) {
-                  try {
-                     in.close();
-                  }
-                  catch ( IOException argh ) {
-                     throw new RuntimeException("Failed to close input stream.", argh);
-                  }
-               }
-            }
-         } else if ( _fieldIsLong ) {
-            DataInputStream in = null;
-            try {
-               in = new DataInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
-               while ( true ) {
-                  Object payload = readPayload(in);
-                  if ( payload != null ) {
-                     mayEOF = false;
-                  }
-                  long key = in.readLong();
-                  mayEOF = false;
-                  long pos = in.readLong();
-                  mayEOF = true;
-                  if ( positionsToIgnore.get(pos) > 0 ) {
-                     positionsToIgnore.adjustValue(pos, -1);
-                     continue;
-                  }
-                  if ( !_dump._deletedPositions.contains(pos) ) {
-                     long previousEntry = _lookupLong.put(key, pos);
-                     if ( previousEntry != _noEntry ) {
-                        _lookupLong.put(key, previousEntry);
-                        throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
-                     }
-                     cachePayload(pos, payload);
-                  }
-               }
-            }
-            catch ( EOFException argh ) {
-               if ( !mayEOF ) {
-                  throw new RuntimeException("Failed to read lookup from " + getLookupFile() + ", file is unbalanced - unexpected EoF", argh);
-               }
-            }
-            catch ( IOException argh ) {
-               throw new RuntimeException("Failed to read lookup from " + getLookupFile(), argh);
-            }
-            finally {
-               if ( in != null ) {
-                  try {
-                     in.close();
-                  }
-                  catch ( IOException argh ) {
-                     throw new RuntimeException("Failed to close input stream.", argh);
-                  }
-               }
-            }
-         } else if ( _fieldIsString ) {
-            DataInputStream in = null;
-            try {
-               in = new DataInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
-               while ( true ) {
-                  Object payload = readPayload(in);
-                  if ( payload != null ) {
-                     mayEOF = false;
-                  }
-                  String key = in.readUTF();
-                  mayEOF = false;
-                  long pos = in.readLong();
-                  mayEOF = true;
-                  if ( positionsToIgnore.get(pos) > 0 ) {
-                     positionsToIgnore.adjustValue(pos, -1);
-                     continue;
-                  }
-                  if ( !_dump._deletedPositions.contains(pos) ) {
-                     long previousEntry = _lookupObject.put(key, pos);
-                     if ( previousEntry != _noEntry ) {
-                        _lookupObject.put(key, previousEntry);
-                        throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
-                     }
-                     cachePayload(pos, payload);
-                  }
-               }
-            }
-            catch ( EOFException argh ) {
-               if ( !mayEOF ) {
-                  throw new RuntimeException("Failed to read lookup from " + getLookupFile() + ", file is unbalanced - unexpected EoF", argh);
-               }
-            }
-            catch ( IOException argh ) {
-               throw new RuntimeException("Failed to read lookup from " + getLookupFile(), argh);
-            }
-            finally {
-               if ( in != null ) {
-                  try {
-                     in.close();
-                  }
-                  catch ( IOException argh ) {
-                     throw new RuntimeException("Failed to close input stream.", argh);
-                  }
-               }
-            }
-         } else {
-            ObjectInput in = null;
-            try {
-               if ( _fieldIsExternalizable ) {
-                  in = new SingleTypeObjectInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())), _fieldAccessor.getType());
-               } else {
-                  in = new ExternalizableObjectInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
-               }
-            }
-            catch ( IOException argh ) {
-               throw new RuntimeException("Failed to initialize dump index with lookup file " + getLookupFile(), argh);
-            }
-            try {
-               while ( true ) {
-                  Object payload = readPayload(in);
-                  if ( payload != null ) {
-                     mayEOF = false;
-                  }
-                  Object key = in.readObject();
-                  mayEOF = false;
-                  long pos = in.readLong();
-                  mayEOF = true;
-                  if ( positionsToIgnore.get(pos) > 0 ) {
-                     positionsToIgnore.adjustValue(pos, -1);
-                     continue;
-                  }
-                  if ( !_dump._deletedPositions.contains(pos) ) {
-                     long previousEntry = _lookupObject.put(key, pos);
-                     if ( previousEntry != _noEntry ) {
-                        _lookupObject.put(key, previousEntry);
-                        throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
-                     }
-                     cachePayload(pos, payload);
-                  }
-               }
-            }
-            catch ( EOFException argh ) {
-               if ( !mayEOF ) {
-                  throw new RuntimeException("Failed to read lookup from " + getLookupFile() + ", file is unbalanced - unexpected EoF", argh);
-               }
-            }
-            catch ( ClassNotFoundException | IOException argh ) {
-               throw new RuntimeException("Failed to read lookup from " + getLookupFile(), argh);
-            }
-            finally {
-               try {
-                  in.close();
-               }
-               catch ( IOException argh ) {
-                  throw new RuntimeException("Failed to close input stream.", argh);
-               }
-            }
-         }
       }
       finally {
          if ( updatesInput != null ) {
@@ -630,6 +438,198 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             }
             catch ( IOException argh ) {
                throw new RuntimeException("Failed to close updates stream.", argh);
+            }
+         }
+      }
+
+      boolean mayEOF = true;
+      final int size = getHeadroomForLoad(getLookupSizeFromFiles());
+      initLookupMap(size);
+      if ( _fieldIsInt ) {
+         DataInputStream in = null;
+         try {
+            in = new DataInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
+            while ( true ) {
+               Object payload = readPayload(in);
+               if ( payload != null ) {
+                  mayEOF = false;
+               }
+               int key = in.readInt();
+               mayEOF = false;
+               long pos = in.readLong();
+               mayEOF = true;
+               if ( positionsToIgnore.get(pos) > 0 ) {
+                  positionsToIgnore.adjustValue(pos, -1);
+                  continue;
+               }
+               if ( !_dump._deletedPositions.contains(pos) ) {
+                  long previousEntry = _lookupInt.put(key, pos);
+                  if ( previousEntry != _noEntry ) {
+                     _lookupInt.put(key, previousEntry);
+                     throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
+                  }
+                  cachePayload(pos, payload);
+               }
+            }
+         }
+         catch ( EOFException argh ) {
+            if ( !mayEOF ) {
+               throw new RuntimeException("Failed to read lookup from " + getLookupFile() + ", file is unbalanced - unexpected EoF", argh);
+            }
+         }
+         catch ( IOException argh ) {
+            throw new RuntimeException("Failed to read lookup from " + getLookupFile(), argh);
+         }
+         finally {
+            if ( in != null ) {
+               try {
+                  in.close();
+               }
+               catch ( IOException argh ) {
+                  throw new RuntimeException("Failed to close input stream.", argh);
+               }
+            }
+         }
+      } else if ( _fieldIsLong ) {
+         DataInputStream in = null;
+         try {
+            in = new DataInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
+            while ( true ) {
+               Object payload = readPayload(in);
+               if ( payload != null ) {
+                  mayEOF = false;
+               }
+               long key = in.readLong();
+               mayEOF = false;
+               long pos = in.readLong();
+               mayEOF = true;
+               if ( positionsToIgnore.get(pos) > 0 ) {
+                  positionsToIgnore.adjustValue(pos, -1);
+                  continue;
+               }
+               if ( !_dump._deletedPositions.contains(pos) ) {
+                  long previousEntry = _lookupLong.put(key, pos);
+                  if ( previousEntry != _noEntry ) {
+                     _lookupLong.put(key, previousEntry);
+                     throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
+                  }
+                  cachePayload(pos, payload);
+               }
+            }
+         }
+         catch ( EOFException argh ) {
+            if ( !mayEOF ) {
+               throw new RuntimeException("Failed to read lookup from " + getLookupFile() + ", file is unbalanced - unexpected EoF", argh);
+            }
+         }
+         catch ( IOException argh ) {
+            throw new RuntimeException("Failed to read lookup from " + getLookupFile(), argh);
+         }
+         finally {
+            if ( in != null ) {
+               try {
+                  in.close();
+               }
+               catch ( IOException argh ) {
+                  throw new RuntimeException("Failed to close input stream.", argh);
+               }
+            }
+         }
+      } else if ( _fieldIsString ) {
+         DataInputStream in = null;
+         try {
+            in = new DataInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
+            while ( true ) {
+               Object payload = readPayload(in);
+               if ( payload != null ) {
+                  mayEOF = false;
+               }
+               String key = in.readUTF();
+               mayEOF = false;
+               long pos = in.readLong();
+               mayEOF = true;
+               if ( positionsToIgnore.get(pos) > 0 ) {
+                  positionsToIgnore.adjustValue(pos, -1);
+                  continue;
+               }
+               if ( !_dump._deletedPositions.contains(pos) ) {
+                  long previousEntry = _lookupObject.put(key, pos);
+                  if ( previousEntry != _noEntry ) {
+                     _lookupObject.put(key, previousEntry);
+                     throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
+                  }
+                  cachePayload(pos, payload);
+               }
+            }
+         }
+         catch ( EOFException argh ) {
+            if ( !mayEOF ) {
+               throw new RuntimeException("Failed to read lookup from " + getLookupFile() + ", file is unbalanced - unexpected EoF", argh);
+            }
+         }
+         catch ( IOException argh ) {
+            throw new RuntimeException("Failed to read lookup from " + getLookupFile(), argh);
+         }
+         finally {
+            if ( in != null ) {
+               try {
+                  in.close();
+               }
+               catch ( IOException argh ) {
+                  throw new RuntimeException("Failed to close input stream.", argh);
+               }
+            }
+         }
+      } else {
+         ObjectInput in = null;
+         try {
+            if ( _fieldIsExternalizable ) {
+               in = new SingleTypeObjectInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())), _fieldAccessor.getType());
+            } else {
+               in = new ExternalizableObjectInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
+            }
+         }
+         catch ( IOException argh ) {
+            throw new RuntimeException("Failed to initialize dump index with lookup file " + getLookupFile(), argh);
+         }
+         try {
+            while ( true ) {
+               Object payload = readPayload(in);
+               if ( payload != null ) {
+                  mayEOF = false;
+               }
+               Object key = in.readObject();
+               mayEOF = false;
+               long pos = in.readLong();
+               mayEOF = true;
+               if ( positionsToIgnore.get(pos) > 0 ) {
+                  positionsToIgnore.adjustValue(pos, -1);
+                  continue;
+               }
+               if ( !_dump._deletedPositions.contains(pos) ) {
+                  long previousEntry = _lookupObject.put(key, pos);
+                  if ( previousEntry != _noEntry ) {
+                     _lookupObject.put(key, previousEntry);
+                     throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
+                  }
+                  cachePayload(pos, payload);
+               }
+            }
+         }
+         catch ( EOFException argh ) {
+            if ( !mayEOF ) {
+               throw new RuntimeException("Failed to read lookup from " + getLookupFile() + ", file is unbalanced - unexpected EoF", argh);
+            }
+         }
+         catch ( ClassNotFoundException | IOException argh ) {
+            throw new RuntimeException("Failed to read lookup from " + getLookupFile(), argh);
+         }
+         finally {
+            try {
+               in.close();
+            }
+            catch ( IOException argh ) {
+               throw new RuntimeException("Failed to close input stream.", argh);
             }
          }
       }

--- a/dump/src/util/dump/UniqueIndex.java
+++ b/dump/src/util/dump/UniqueIndex.java
@@ -104,7 +104,8 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             throw new IllegalArgumentException(
                   "The type of the used key class of this index is " + _fieldAccessor.getType() + ". Please use the appropriate contains(.) method.");
          }
-         return _lookupInt.containsKey(key) && !_dump._deletedPositions.contains(_lookupInt.get(key));
+         long pos = _lookupInt.get(key);
+         return pos != _noEntry && !_dump._deletedPositions.contains(pos);
       }
    }
 
@@ -115,7 +116,8 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             throw new IllegalArgumentException(
                   "The type of the used key class of this index is " + _fieldAccessor.getType() + ". Please use the appropriate contains(.) method.");
          }
-         return _lookupLong.containsKey(key) && !_dump._deletedPositions.contains(_lookupLong.get(key));
+         long pos = _lookupLong.get(key);
+         return pos != _noEntry && !_dump._deletedPositions.contains(pos);
       }
    }
 
@@ -132,7 +134,8 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             throw new IllegalArgumentException(
                   "The type of the used key class of this index is " + _fieldAccessor.getType() + ". Please use the appropriate contains(.) method.");
          }
-         return _lookupObject.containsKey(key) && !_dump._deletedPositions.contains(_lookupObject.get(key));
+         long pos = _lookupObject.get(key);
+         return pos != _noEntry && !_dump._deletedPositions.contains(pos);
       }
    }
 

--- a/dump/src/util/dump/UniqueIndex.java
+++ b/dump/src/util/dump/UniqueIndex.java
@@ -373,6 +373,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             int size = (int)(getLookupFile().length() / (4 + 8));
             size = getHeadroomForLoad(size);
             _lookupInt = new TIntLongHashMap(size);
+            long noEntry = _lookupInt.getNoEntryValue();
             DataInputStream in = null;
             try {
                in = new DataInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
@@ -389,11 +390,12 @@ public class UniqueIndex<E> extends DumpIndex<E> {
                      positionsToIgnore.adjustValue(pos, -1);
                      continue;
                   }
-                  if ( _lookupInt.containsKey(key) ) {
-                     throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
-                  }
                   if ( !_dump._deletedPositions.contains(pos) ) {
-                     _lookupInt.put(key, pos);
+                     long previousEntry = _lookupInt.put(key, pos);
+                     if ( previousEntry != noEntry ) {
+                        _lookupInt.put(key, previousEntry);
+                        throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
+                     }
                      cachePayload(pos, payload);
                   }
                }
@@ -420,6 +422,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             int size = (int)(getLookupFile().length() / (8 + 8));
             size = getHeadroomForLoad(size);
             _lookupLong = new TLongLongHashMap(size);
+            long noEntry = _lookupLong.getNoEntryValue();
             DataInputStream in = null;
             try {
                in = new DataInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
@@ -436,11 +439,12 @@ public class UniqueIndex<E> extends DumpIndex<E> {
                      positionsToIgnore.adjustValue(pos, -1);
                      continue;
                   }
-                  if ( _lookupLong.containsKey(key) ) {
-                     throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
-                  }
                   if ( !_dump._deletedPositions.contains(pos) ) {
-                     _lookupLong.put(key, pos);
+                     long previousEntry = _lookupLong.put(key, pos);
+                     if ( previousEntry != noEntry ) {
+                        _lookupLong.put(key, previousEntry);
+                        throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
+                     }
                      cachePayload(pos, payload);
                   }
                }
@@ -467,6 +471,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             int size = (int)(getLookupFile().length() / (10 + 8)); // let's assume an average length of the String keys of 10 bytes
             size = getHeadroomForLoad(size);
             _lookupObject = new TObjectLongHashMap(size);
+            long noEntry = _lookupObject.getNoEntryValue();
             DataInputStream in = null;
             try {
                in = new DataInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
@@ -483,11 +488,12 @@ public class UniqueIndex<E> extends DumpIndex<E> {
                      positionsToIgnore.adjustValue(pos, -1);
                      continue;
                   }
-                  if ( _lookupObject.containsKey(key) ) {
-                     throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
-                  }
                   if ( !_dump._deletedPositions.contains(pos) ) {
-                     _lookupObject.put(key, pos);
+                     long previousEntry = _lookupObject.put(key, pos);
+                     if ( previousEntry != noEntry ) {
+                        _lookupObject.put(key, previousEntry);
+                        throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
+                     }
                      cachePayload(pos, payload);
                   }
                }
@@ -514,6 +520,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             int size = (int)(getLookupFile().length() / (20 + 8)); // let's assume an average length of the keys of 20 bytes
             size = getHeadroomForLoad(size);
             _lookupObject = new TObjectLongHashMap(size);
+            long noEntry = _lookupObject.getNoEntryValue();
             ObjectInput in = null;
             try {
                if ( _fieldIsExternalizable ) {
@@ -539,11 +546,12 @@ public class UniqueIndex<E> extends DumpIndex<E> {
                      positionsToIgnore.adjustValue(pos, -1);
                      continue;
                   }
-                  if ( _lookupObject.containsKey(key) ) {
-                     throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
-                  }
                   if ( !_dump._deletedPositions.contains(pos) ) {
-                     _lookupObject.put(key, pos);
+                     long previousEntry = _lookupObject.put(key, pos);
+                     if ( previousEntry != noEntry ) {
+                        _lookupObject.put(key, previousEntry);
+                        throw new DuplicateKeyException("index lookup " + getLookupFile() + " is broken - contains non unique key " + key);
+                     }
                      cachePayload(pos, payload);
                   }
                }

--- a/dump/src/util/dump/UniqueIndex.java
+++ b/dump/src/util/dump/UniqueIndex.java
@@ -218,23 +218,26 @@ public class UniqueIndex<E> extends DumpIndex<E> {
 
       int lookupSize = Integer.parseInt(indexMeta._metaData.getOrDefault("lookupSize", "" + Constants.DEFAULT_CAPACITY));
       if ( lookupSize <= Constants.DEFAULT_CAPACITY && getLookupFile().exists() ) {
-         lookupSize = getLookupSizeFromFile();
+         lookupSize = getLookupSizeFromFiles();
       }
       _lookupSize = Math.max(_lookupSize, lookupSize);
 
       return indexMeta._valid;
    }
 
-   private int getLookupSizeFromFile() {
+   private int getLookupSizeFromFiles() {
+      int lookupPositions;
       if ( _fieldIsInt ) {
-         return (int)(getLookupFile().length() / (4 + 8));
+         lookupPositions = (int)(getLookupFile().length() / (4 + 8));
       } else if ( _fieldIsLong ) {
-         return (int)(getLookupFile().length() / (8 + 8));
+         lookupPositions = (int)(getLookupFile().length() / (8 + 8));
       } else if ( _fieldIsString ) {
-         return (int)(getLookupFile().length() / (10 + 8)); // let's assume an average length of the String keys of 10 bytes
+         lookupPositions = (int)(getLookupFile().length() / (10 + 8)); // let's assume an average length of the String keys of 10 bytes
       } else {
-         return (int)(getLookupFile().length() / (20 + 8)); // let's assume an average length of the keys of 20 bytes
+         lookupPositions = (int)(getLookupFile().length() / (20 + 8)); // let's assume an average length of the keys of 20 bytes
       }
+      int updatedPositions = !getUpdatesFile().exists() ? 0 : (int)(getUpdatesFile().length() / 8);
+      return lookupPositions - updatedPositions;
    }
 
    public E lookup( int key ) {
@@ -415,7 +418,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
          }
 
          boolean mayEOF = true;
-         final int size = getHeadroomForLoad(getLookupSizeFromFile());
+         final int size = getHeadroomForLoad(getLookupSizeFromFiles());
          if ( _fieldIsInt ) {
             _lookupInt = new TIntLongHashMap(size);
             long noEntry = _lookupInt.getNoEntryValue();

--- a/dump/src/util/dump/UniqueIndex.java
+++ b/dump/src/util/dump/UniqueIndex.java
@@ -233,7 +233,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
       return indexMeta._valid;
    }
 
-   private int getLookupSizeFromFiles() {
+   protected int getLookupSizeFromFiles() {
       int lookupPositions;
       if ( _fieldIsInt ) {
          lookupPositions = (int)(getLookupFile().length() / (4 + 8));
@@ -368,7 +368,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
       }
    }
 
-   private void initLookupMap( int size ) {
+   protected void initLookupMap( int size ) {
       if ( _fieldIsInt ) {
          _lookupInt = new TIntLongHashMap(size);
          _noEntry = _lookupInt.getNoEntryValue();
@@ -656,7 +656,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
       }
    }
 
-   private static int getHeadroomForLoad( int size ) {
+   protected static int getHeadroomForLoad( int size ) {
       return size * 11 / 10; // 10% should be more than enough headroom to avoid involuntary rehashing
    }
 
@@ -725,7 +725,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
        * This is handled during load() using getUpdatesFile() */
    }
 
-   private void addToIgnoredPositions( long pos ) {
+   protected void addToIgnoredPositions( long pos ) {
       try {
          // we add this position to the stream of ignored positions used during load()
          getUpdatesOutput().writeLong(pos);

--- a/dump/src/util/dump/UniqueIndex.java
+++ b/dump/src/util/dump/UniqueIndex.java
@@ -310,12 +310,6 @@ public class UniqueIndex<E> extends DumpIndex<E> {
    }
 
    @Override
-   protected void init() {
-      super.init();
-      compactLookup();
-   }
-
-   @Override
    protected void initFromDump() {
       super.initFromDump();
 
@@ -377,7 +371,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
          boolean mayEOF = true;
          if ( _fieldIsInt ) {
             int size = (int)(getLookupFile().length() / (4 + 8));
-            size = Math.max(10000, size + 1000);
+            size = getHeadroomForLoad(size);
             _lookupInt = new TIntLongHashMap(size);
             DataInputStream in = null;
             try {
@@ -424,7 +418,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             }
          } else if ( _fieldIsLong ) {
             int size = (int)(getLookupFile().length() / (8 + 8));
-            size = Math.max(10000, size + 1000);
+            size = getHeadroomForLoad(size);
             _lookupLong = new TLongLongHashMap(size);
             DataInputStream in = null;
             try {
@@ -471,7 +465,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             }
          } else if ( _fieldIsString ) {
             int size = (int)(getLookupFile().length() / (10 + 8)); // let's assume an average length of the String keys of 10 bytes
-            size = Math.max(10000, size + 1000);
+            size = getHeadroomForLoad(size);
             _lookupObject = new TObjectLongHashMap(size);
             DataInputStream in = null;
             try {
@@ -518,7 +512,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             }
          } else {
             int size = (int)(getLookupFile().length() / (20 + 8)); // let's assume an average length of the keys of 20 bytes
-            size = Math.max(10000, size + 1000);
+            size = getHeadroomForLoad(size);
             _lookupObject = new TObjectLongHashMap(size);
             ObjectInput in = null;
             try {
@@ -582,6 +576,10 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             }
          }
       }
+   }
+
+   private static int getHeadroomForLoad( int size ) {
+      return size * 11 / 10; // 10% should be more than enough headroom to avoid involuntary rehashing
    }
 
    protected long readNextPosition( DataInputStream updatesInput ) {

--- a/dump/test/util/dump/DumpTest.java
+++ b/dump/test/util/dump/DumpTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.security.AccessControlException;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.BiFunction;
 
 import org.junit.After;
 import org.junit.Before;
@@ -24,6 +25,10 @@ import util.dump.ExternalizableBeanTest.TestBeanPadding;
 
 
 public class DumpTest {
+
+   protected <E> UniqueIndex<E> newUniqueIndex(Dump<E> dump, String fieldName) throws NoSuchFieldException {
+      return new UniqueIndex<>(dump, fieldName);
+   }
 
    @Before
    @After
@@ -52,7 +57,7 @@ public class DumpTest {
          dump.add(new Bean(1));
          dump.delete(0);
          dump.add(new Bean(1));
-         new UniqueIndex<>(dump, "_id");
+         newUniqueIndex(dump, "_id");
       }
    }
 
@@ -204,7 +209,7 @@ public class DumpTest {
    public void testReOpening() throws IOException, NoSuchFieldException {
       File dumpFile = new File("DumpTest.dmp");
       Dump<Bean> dump = new Dump<>(Bean.class, dumpFile);
-      UniqueIndex<Bean> index = new UniqueIndex<>(dump, "_id");
+      UniqueIndex<Bean> index = newUniqueIndex(dump, "_id");
       for ( int j = 0; j < 100000; j++ ) {
          dump.add(new Bean(j));
       }
@@ -221,7 +226,7 @@ public class DumpTest {
       dump.close();
 
       dump = new Dump<>(Bean.class, dumpFile);
-      index = new UniqueIndex<>(dump, "_id");
+      index = newUniqueIndex(dump, "_id");
       for ( int j = 100000; j < 200000; j++ ) {
          dump.add(new Bean(j));
       }

--- a/dump/test/util/dump/DumpUtilsTest.java
+++ b/dump/test/util/dump/DumpUtilsTest.java
@@ -25,6 +25,10 @@ public class DumpUtilsTest {
 
    private static final int NUMBER_OF_INSTANCES = 10000;
 
+   protected <E> UniqueIndex<E> newUniqueIndex(Dump<E> dump, String fieldName) throws NoSuchFieldException {
+      return new UniqueIndex<>(dump, fieldName);
+   }
+
    @Before
    @After
    public void deleteOldTestDumps() {
@@ -143,7 +147,7 @@ public class DumpUtilsTest {
       try {
          File dumpFile = File.createTempFile("dump", ".tmp", tmpDir);
          Dump<Bean> dump = new Dump<>(Bean.class, dumpFile);
-         UniqueIndex<Bean> index = new UniqueIndex<>(dump, "_id");
+         UniqueIndex<Bean> index = newUniqueIndex(dump, "_id");
          dump.add(new Bean(1));
 
          DumpUtils.deleteDumpIndexFiles(dump);

--- a/dump/test/util/dump/DumpUtils_WithMmappedIndex_Test.java
+++ b/dump/test/util/dump/DumpUtils_WithMmappedIndex_Test.java
@@ -1,0 +1,10 @@
+package util.dump;
+
+public class DumpUtils_WithMmappedIndex_Test extends DumpUtilsTest {
+
+   @Override
+   protected <E> UniqueIndex<E> newUniqueIndex( Dump<E> dump, String fieldName ) throws NoSuchFieldException {
+      return new MmappedUniqueIndex<>(dump, fieldName);
+   }
+
+}

--- a/dump/test/util/dump/Dump_WithMmappedIndex_Test.java
+++ b/dump/test/util/dump/Dump_WithMmappedIndex_Test.java
@@ -1,0 +1,10 @@
+package util.dump;
+
+public class Dump_WithMmappedIndex_Test extends DumpTest {
+
+   @Override
+   protected <E> UniqueIndex<E> newUniqueIndex( Dump<E> dump, String fieldName ) throws NoSuchFieldException {
+      return new MmappedUniqueIndex<>(dump, fieldName);
+   }
+
+}

--- a/dump/test/util/dump/UniqueIndexDeletionTest.java
+++ b/dump/test/util/dump/UniqueIndexDeletionTest.java
@@ -18,6 +18,11 @@ public class UniqueIndexDeletionTest {
    private static final String DUMP_FILENAME = "UniqueIndexDeletionTest.dmp";
    private static       File   _tmpdir;
 
+   protected <E> UniqueIndex<E> newUniqueIndex(Dump<E> dump, String fieldName) throws NoSuchFieldException {
+      return new UniqueIndex<>(dump, fieldName);
+   }
+
+
    @BeforeClass
    public static void setUpTmpdir() throws IOException {
       _tmpdir = new File("target", "tmp");
@@ -47,7 +52,7 @@ public class UniqueIndexDeletionTest {
       Dump<UniqueIndexTest.Bean> dump = null;
       try {
          dump = new Dump<>(UniqueIndexTest.Bean.class, dumpFile);
-         UniqueIndex<UniqueIndexTest.Bean> intIndex = new UniqueIndex<>(dump, "_idInt");
+         UniqueIndex<UniqueIndexTest.Bean> intIndex = newUniqueIndex(dump, "_idInt");
          UniqueIndex<UniqueIndexTest.Bean> stringIndex = new UniqueIndex<>(dump, "_idString");
 
          dump.add(new UniqueIndexTest.Bean(1, "data"));
@@ -68,7 +73,7 @@ public class UniqueIndexDeletionTest {
          Arrays.stream(Objects.requireNonNull(_tmpdir.listFiles(s -> s.getName().contains("_idString")))).forEach(File::delete);
 
          dump = new Dump<>(UniqueIndexTest.Bean.class, dumpFile);
-         intIndex = new UniqueIndex<>(dump, "_idInt");
+         intIndex = newUniqueIndex(dump, "_idInt");
          stringIndex = new UniqueIndex<>(dump, "_idString");
 
          bean = intIndex.lookup(1);

--- a/dump/test/util/dump/UniqueIndexDeletion_WithMmappedIndex_Test.java
+++ b/dump/test/util/dump/UniqueIndexDeletion_WithMmappedIndex_Test.java
@@ -1,0 +1,9 @@
+package util.dump;
+
+public class UniqueIndexDeletion_WithMmappedIndex_Test extends UniqueIndexDeletionTest {
+
+   @Override
+   protected <E> UniqueIndex<E> newUniqueIndex( Dump<E> dump, String fieldName ) throws NoSuchFieldException {
+      return new MmappedUniqueIndex<>(dump, fieldName);
+   }
+}

--- a/dump/test/util/dump/UniqueIndexTest.java
+++ b/dump/test/util/dump/UniqueIndexTest.java
@@ -35,6 +35,14 @@ public class UniqueIndexTest {
    private static final int    BEAN_SIZE     = 10;
    private static       File   _tmpdir;
 
+   protected <E> UniqueIndex<E> newUniqueIndex( Dump<E> dump, String fieldName ) throws NoSuchFieldException {
+      return new UniqueIndex<>(dump, fieldName);
+   }
+
+   protected <E> UniqueIndex<E> newUniqueIndex( Dump<E> dump, FieldFieldAccessor fieldAccessor ) {
+      return new UniqueIndex<>(dump, fieldAccessor);
+   }
+
    @Parameters
    public static Collection<Object[]> getDumpSizesToTestFor() {
       List<Object[]> parameters = new ArrayList<>();
@@ -102,7 +110,6 @@ public class UniqueIndexTest {
             return new ExternalizableId(id);
          }
       });
-
    }
 
    @Test
@@ -119,8 +126,8 @@ public class UniqueIndexTest {
          dump.close();
          dump = new Dump<>(Bean.class, dumpFile);
 
-         DumpIndex<Bean> intIndex = new UniqueIndex<>(dump, "_idInt");
-         DumpIndex<Bean> longIndex = new UniqueIndex<>(dump, "_idLong");
+         DumpIndex<Bean> intIndex = newUniqueIndex(dump, "_idInt");
+         DumpIndex<Bean> longIndex = newUniqueIndex(dump, "_idLong");
          DumpIndex<Bean> stringIndex = new UniqueIndex<>(dump, "_idString");
 
          assertThat(longIndex.getNumKeys()).isEqualTo(numBeansToAddForTest);
@@ -184,7 +191,7 @@ public class UniqueIndexTest {
       Dump<Bean> dump = new Dump<>(Bean.class, dumpFile);
       try {
          Field field = Reflection.getField(Bean.class, "_idInt");
-         UniqueIndex<Bean> index = new UniqueIndex<>(dump, new FieldFieldAccessor(field));
+         UniqueIndex<Bean> index = newUniqueIndex(dump, new FieldFieldAccessor(field));
 
          validateNumKeys(dump, index);
 
@@ -199,7 +206,7 @@ public class UniqueIndexTest {
                new File(_tmpdir, DUMP_FILENAME + "._idInt.lookup").delete() && !new File(_tmpdir, DUMP_FILENAME + "._idInt.lookup").exists());
 
          dump = new Dump<>(Bean.class, dumpFile);
-         index = new UniqueIndex<>(dump, new FieldFieldAccessor(field));
+         index = newUniqueIndex(dump, new FieldFieldAccessor(field));
 
          long t = System.currentTimeMillis();
          for ( int j = 0; j < READ_NUMBER; j++ ) {
@@ -242,7 +249,7 @@ public class UniqueIndexTest {
       Dump<Bean> dump = new Dump<>(Bean.class, dumpFile);
       try {
          Field field = Reflection.getField(Bean.class, fieldName);
-         UniqueIndex<Bean> index = new UniqueIndex<>(dump, new FieldFieldAccessor(field));
+         UniqueIndex<Bean> index = newUniqueIndex(dump, new FieldFieldAccessor(field));
 
          fillDump(dump);
 
@@ -255,7 +262,7 @@ public class UniqueIndexTest {
          System.out.println("Closing and re-opening dump");
 
          dump = new Dump<>(Bean.class, dumpFile);
-         index = new UniqueIndex<>(dump, new FieldFieldAccessor(field));
+         index = newUniqueIndex(dump, new FieldFieldAccessor(field));
 
          validateNumKeys(dump, index);
 
@@ -343,7 +350,7 @@ public class UniqueIndexTest {
          System.out.println("Closing and re-opening dump");
 
          dump = new Dump<>(Bean.class, dumpFile);
-         index = new UniqueIndex<>(dump, new FieldFieldAccessor(field));
+         index = newUniqueIndex(dump, new FieldFieldAccessor(field));
 
          validateNumKeys(dump, index);
 
@@ -364,7 +371,7 @@ public class UniqueIndexTest {
          }
          /* re-open, enforcing the index to be re-created */
          dump = new Dump<>(Bean.class, dumpFile);
-         index = new UniqueIndex<>(dump, new FieldFieldAccessor(field));
+         index = newUniqueIndex(dump, new FieldFieldAccessor(field));
 
          validateNumKeys(dump, index);
 
@@ -400,7 +407,7 @@ public class UniqueIndexTest {
          Field field = Reflection.getField(Bean.class, fieldName);
 
          fillDump(dump);
-         UniqueIndex<Bean> index = new UniqueIndex<>(dump, new FieldFieldAccessor(field));
+         UniqueIndex<Bean> index = newUniqueIndex(dump, new FieldFieldAccessor(field));
 
          testLookup(config, field, index);
       }

--- a/dump/test/util/dump/UniqueIndex_WithMmappedIndex_Test.java
+++ b/dump/test/util/dump/UniqueIndex_WithMmappedIndex_Test.java
@@ -1,0 +1,27 @@
+package util.dump;
+
+import util.dump.reflection.FieldFieldAccessor;
+
+
+public class UniqueIndex_WithMmappedIndex_Test extends UniqueIndexTest {
+
+   public UniqueIndex_WithMmappedIndex_Test( Integer dumpSize ) {
+      super(dumpSize);
+   }
+
+   @Override
+   protected <E> UniqueIndex<E> newUniqueIndex( Dump<E> dump, String fieldName ) throws NoSuchFieldException {
+      return new MmappedUniqueIndex<>(dump, fieldName);
+   }
+
+   @Override
+   protected <E> UniqueIndex<E> newUniqueIndex( Dump<E> dump, FieldFieldAccessor fieldAccessor ) {
+      Class fieldType = fieldAccessor.getType();
+      if ( fieldType == int.class || fieldType == Integer.class || fieldType == long.class || fieldType == Long.class ) {
+         return new MmappedUniqueIndex<>(dump, fieldAccessor);
+      } else {
+         return new UniqueIndex<>(dump, fieldAccessor);
+      }
+   }
+
+}


### PR DESCRIPTION
Unconditional voluntary compaction after initialization is pretty much a waste of time. We can do better and hit far closer to home with our guesstimations.