### PR TITLE
UniqueIndex, GroupIndex: avoid spurious auto-compaction of trove-based containers

### DIFF
--- a/dump/pom.xml
+++ b/dump/pom.xml
@@ -8,7 +8,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20230313.1</version>
+      <version>1.20230406.1</version>
    </parent>
 
    <dependencies>

--- a/dump/src/util/dump/GroupIndex.java
+++ b/dump/src/util/dump/GroupIndex.java
@@ -22,6 +22,7 @@ import gnu.trove.map.TLongIntMap;
 import gnu.trove.map.TLongObjectMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.map.hash.TLongIntHashMap;
+import gnu.trove.map.hash.TLongLongHashMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import gnu.trove.procedure.TIntObjectProcedure;
 import gnu.trove.procedure.TLongObjectProcedure;
@@ -322,8 +323,10 @@ public class GroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex<E> {
    protected void initLookupMap() {
       if ( _fieldIsInt ) {
          _lookupInt = new TIntObjectHashMap<>();
+         ((TIntObjectHashMap)_lookupInt).setAutoCompactionFactor(0.0f);
       } else if ( _fieldIsLong ) {
          _lookupLong = new TLongObjectHashMap<>();
+         ((TLongObjectHashMap)_lookupLong).setAutoCompactionFactor(0.0f);
       } else {
          _lookupObject = new HashMap<>();
       }
@@ -410,6 +413,7 @@ public class GroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex<E> {
                }
             });
             _lookupInt = lookupInt;
+            ((TIntObjectHashMap)_lookupInt).setAutoCompactionFactor(0.0f);
 
          } else if ( _fieldIsLong ) {
             TLongObjectMap<Positions> dynamicLookupLong = new TLongObjectHashMap<>(10000);
@@ -465,6 +469,7 @@ public class GroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex<E> {
                }
             });
             _lookupLong = lookupLong;
+            ((TLongObjectHashMap)_lookupLong).setAutoCompactionFactor(0.0f);
 
          } else if ( _fieldIsString ) {
             HashMap<Object, Positions> lookupObject = new HashMap<>(10000);

--- a/dump/src/util/dump/UniqueIndex.java
+++ b/dump/src/util/dump/UniqueIndex.java
@@ -331,10 +331,13 @@ public class UniqueIndex<E> extends DumpIndex<E> {
    protected void initLookupMap() {
       if ( _fieldIsInt ) {
          _lookupInt = new TIntLongHashMap();
+         _lookupInt.setAutoCompactionFactor(0.0f);
       } else if ( _fieldIsLong ) {
          _lookupLong = new TLongLongHashMap();
+         _lookupLong.setAutoCompactionFactor(0.0f);
       } else {
          _lookupObject = new TObjectLongHashMap();
+         _lookupObject.setAutoCompactionFactor(0.0f);
       }
    }
 
@@ -379,6 +382,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             int size = (int)(getLookupFile().length() / (4 + 8));
             size = Math.max(10000, size + 1000);
             _lookupInt = new TIntLongHashMap(size);
+            _lookupInt.setAutoCompactionFactor(0.0f);
             DataInputStream in = null;
             try {
                in = new DataInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
@@ -426,6 +430,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             int size = (int)(getLookupFile().length() / (8 + 8));
             size = Math.max(10000, size + 1000);
             _lookupLong = new TLongLongHashMap(size);
+            _lookupLong.setAutoCompactionFactor(0.0f);
             DataInputStream in = null;
             try {
                in = new DataInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
@@ -473,6 +478,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             int size = (int)(getLookupFile().length() / (10 + 8)); // let's assume an average length of the String keys of 10 bytes
             size = Math.max(10000, size + 1000);
             _lookupObject = new TObjectLongHashMap(size);
+            _lookupObject.setAutoCompactionFactor(0.0f);
             DataInputStream in = null;
             try {
                in = new DataInputStream(new BufferedInputStream(new FileInputStream(getLookupFile())));
@@ -520,6 +526,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
             int size = (int)(getLookupFile().length() / (20 + 8)); // let's assume an average length of the keys of 20 bytes
             size = Math.max(10000, size + 1000);
             _lookupObject = new TObjectLongHashMap(size);
+            _lookupObject.setAutoCompactionFactor(0.0f);
             ObjectInput in = null;
             try {
                if ( _fieldIsExternalizable ) {

--- a/dump/src/util/dump/UniqueIndexWithIntPayload.java
+++ b/dump/src/util/dump/UniqueIndexWithIntPayload.java
@@ -108,6 +108,7 @@ public class UniqueIndexWithIntPayload<E> extends UniqueIndex<E> {
    protected void initLookupMap() {
       super.initLookupMap();
       _posToPayload = new TLongIntHashMap();
+      ((TLongIntHashMap)_posToPayload).setAutoCompactionFactor(0.0f);
    }
 
    @Override

--- a/dump/src/util/dump/UniqueIndexWithLongPayload.java
+++ b/dump/src/util/dump/UniqueIndexWithLongPayload.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.function.ToLongFunction;
 
 import gnu.trove.map.TLongLongMap;
+import gnu.trove.map.hash.TLongIntHashMap;
 import gnu.trove.map.hash.TLongLongHashMap;
 import util.dump.reflection.FieldAccessor;
 
@@ -115,6 +116,7 @@ public class UniqueIndexWithLongPayload<E> extends UniqueIndex<E> {
    protected void initLookupMap() {
       super.initLookupMap();
       _posToPayload = new TLongLongHashMap();
+      ((TLongLongHashMap)_posToPayload).setAutoCompactionFactor(0.0f);
    }
 
    @Override

--- a/dump/src/util/dump/UniqueIndexWithObjectPayload.java
+++ b/dump/src/util/dump/UniqueIndexWithObjectPayload.java
@@ -7,6 +7,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import gnu.trove.map.TLongObjectMap;
+import gnu.trove.map.hash.TLongLongHashMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import util.dump.reflection.FieldAccessor;
 
@@ -118,6 +119,7 @@ public class UniqueIndexWithObjectPayload<E, P> extends UniqueIndex<E> {
    protected void initLookupMap() {
       super.initLookupMap();
       _posToPayload = new TLongObjectHashMap<>();
+      ((TLongObjectHashMap)_posToPayload).setAutoCompactionFactor(0.0f);
    }
 
    @Override

--- a/dumpsearch/pom.xml
+++ b/dumpsearch/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20230313.1</version>
+      <version>1.20230406.1</version>
    </parent>
 
    <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <groupId>mkr</groupId>
    <artifactId>dump-pom</artifactId>
    <name>mkr dump pom</name>
-   <version>1.20230313.1</version>
+   <version>1.20230406.1</version>
    <packaging>pom</packaging>
 
    <modules>


### PR DESCRIPTION
Rationale

We routinely remove and add the very same element during update. The auto-compaction feature counts down a number of remove operations, by default load factor * used size at the time of recalculation. This is meant for hash tables which actually lose their contents over time, which is not the case in our most frequent scenario. We thus tend to waste time, increase latency, and GC overhead, by needlessly rehashing tables which did neither grow nor shrink, nor filled up free slots with removed entries.

The rehash due to lack of free slots is unaffected by this, so if we actually replace old values being deleted with new values being added, the tables will not be clogged up with removed slots whatsoever.

In case a dump should truly shrink over time, our existing explicit size vs. capacity check during removal takes care of appropriate map sizing.