### PR TITLE
DeletionAwareDumpReader: render #hasNext() idempotent

### DIFF
--- a/dump/pom.xml
+++ b/dump/pom.xml
@@ -8,7 +8,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20230531.1</version>
+      <version>1.20230601.1</version>
    </parent>
 
    <dependencies>

--- a/dump/src/util/dump/Dump.java
+++ b/dump/src/util/dump/Dump.java
@@ -1697,6 +1697,9 @@ public class Dump<E> implements DumpInput<E> {
 
       @Override
       public boolean hasNext() {
+         if ( _nextPrepared ) {
+            return true;  // take shortcut, be idempotent
+         }
          synchronized ( Dump.this ) {
             long pos;
             boolean hasNext;

--- a/dumpsearch/pom.xml
+++ b/dumpsearch/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20230531.1</version>
+      <version>1.20230601.1</version>
    </parent>
 
    <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <groupId>mkr</groupId>
    <artifactId>dump-pom</artifactId>
    <name>mkr dump pom</name>
-   <version>1.20230531.1</version>
+   <version>1.20230601.1</version>
    <packaging>pom</packaging>
 
    <modules>


### PR DESCRIPTION
If #hasNext() advances several times without intermittent element retrievals through #next(), elements might be silently skipped if subsequent positions are deleted.

_positionAwareInputStream._rafPos has advanced in the meantime, so we do not initialize to the same position twice. In case the subsequent #hasNext() happens upon a deleted position, the super.next() != null check drops the element that should have been yielded by a call to #next().

This duplicates the _nextPrepared check to ensure #hasNext() and #next() do actual work in proper lockstep at all times.
