### PR TITLE
Fix idempotency of dump iterator hasNext

### DIFF
--- a/dump/pom.xml
+++ b/dump/pom.xml
@@ -8,7 +8,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20230531.1</version>
+      <version>1.20230602.1</version>
    </parent>
 
    <dependencies>

--- a/dump/src/util/dump/Dump.java
+++ b/dump/src/util/dump/Dump.java
@@ -1698,6 +1698,10 @@ public class Dump<E> implements DumpInput<E> {
       @Override
       public boolean hasNext() {
          synchronized ( Dump.this ) {
+            if ( _nextPrepared ) {
+               return _nextObject != null;
+            }
+
             long pos;
             boolean hasNext;
             do {

--- a/dumpsearch/pom.xml
+++ b/dumpsearch/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20230531.1</version>
+      <version>1.20230602.1</version>
    </parent>
 
    <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <groupId>mkr</groupId>
    <artifactId>dump-pom</artifactId>
    <name>mkr dump pom</name>
-   <version>1.20230531.1</version>
+   <version>1.20230602.1</version>
    <packaging>pom</packaging>
 
    <modules>


### PR DESCRIPTION
In comparison to #23, it checks the `_nextObject` and adds a test.