### PR TITLE
Fix incomplete reads

### DIFF
--- a/dump/pom.xml
+++ b/dump/pom.xml
@@ -8,7 +8,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20230602.1</version>
+      <version>1.20230607.1</version>
    </parent>
 
    <dependencies>

--- a/dumpsearch/pom.xml
+++ b/dumpsearch/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20230602.1</version>
+      <version>1.20230607.1</version>
    </parent>
 
    <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <groupId>mkr</groupId>
    <artifactId>dump-pom</artifactId>
    <name>mkr dump pom</name>
-   <version>1.20230602.1</version>
+   <version>1.20230607.1</version>
    <packaging>pom</packaging>
 
    <modules>


### PR DESCRIPTION
Properly blocks where previously non-blocking reads did yield short results, effectively corrupting the de-externalized output.