### PR TITLE
TECH: Remove DumpUtils.cleanup

### DIFF
--- a/dump/test/util/dump/DumpUtilsTest.java
+++ b/dump/test/util/dump/DumpUtilsTest.java
@@ -8,81 +8,26 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileFilter;
-import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.util.Objects;
 
 import org.assertj.core.util.Files;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import junit.framework.Assert;
 import util.dump.DumpTest.Bean;
 
 
 public class DumpUtilsTest {
 
-   private static final int NUMBER_OF_INSTANCES = 10000;
-
    @Before
    @After
    public void deleteOldTestDumps() {
-      File[] dumpFile = new File(".").listFiles(new FileFilter() {
-
-         @Override
-         public boolean accept( File f ) {
-            return f.getName().startsWith("DumpUtilsTest");
-         }
-      });
-      for ( File df : dumpFile ) {
+      File[] dumpFile = new File(".").listFiles(f -> f.getName().startsWith("DumpUtilsTest"));
+      for ( File df : Objects.requireNonNull(dumpFile) ) {
          if ( !df.delete() ) {
             System.out.println("Failed to delete old dump file " + df);
          }
-      }
-   }
-
-   @Test
-   public void testCleanup_broken() throws Exception {
-      testCleanupBroken(200, "broken data", 0);
-   }
-
-   @Test
-   public void testCleanup_brokenAndDeleted() throws Exception {
-      testCleanupBroken(200, "broken data", 3);
-   }
-
-   @Test
-   public void testCleanup_brokenMoreAndDeleted() throws Exception {
-      testCleanupBroken(200, "broken data broken data broken data", 3);
-   }
-
-   @Test
-   public void testCleanup_deleted() throws IOException {
-      Dump<Bean> source = null;
-      Dump<Bean> dest = null;
-      try {
-         source = createSourceDump();
-
-         long sourceSizeAfterAdding = source.getDumpSize();
-
-         deleteFromDump(source, 2);
-
-         long sourceSizeAfterDeleting = source.getDumpSize();
-
-         Assert.assertTrue("Dump shrank after deletions", sourceSizeAfterAdding <= sourceSizeAfterDeleting);
-
-         dest = createDestDump();
-
-         DumpUtils.cleanup(source, dest);
-
-         long destSizeAfterCleanup = dest.getDumpSize();
-
-         Assert.assertTrue("Dump did not shrink after cleanup", destSizeAfterCleanup < sourceSizeAfterDeleting);
-      }
-      finally {
-         DumpUtils.closeSilently(source);
-         DumpUtils.closeSilently(dest);
       }
    }
 
@@ -186,9 +131,7 @@ public class DumpUtilsTest {
    @Test
    public void testReadWriteUtf() throws Exception {
       StringBuilder s = new StringBuilder();
-      for ( int i = 0; i < 10000; i++ ) {
-         s.append("0123456789");
-      }
+      s.append("0123456789".repeat(10000));
 
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       DataOutputStream out = new DataOutputStream(bos);
@@ -200,87 +143,5 @@ public class DumpUtilsTest {
       in.close();
 
       assertThat(s.toString()).isEqualTo(ss);
-   }
-
-   private Dump<Bean> createDestDump() {
-      Dump<Bean> dest;
-      File destFile = new File("DumpUtilsTest-destination.dmp");
-      dest = new Dump<>(Bean.class, destFile);
-      return dest;
-   }
-
-   private Dump<Bean> createSourceDump() throws IOException {
-      Dump<Bean> source;
-      File sourceFile = new File("DumpUtilsTest-source.dmp");
-      source = new Dump<>(Bean.class, sourceFile);
-
-      for ( int i = 0; i < NUMBER_OF_INSTANCES; i++ ) {
-         source.add(new Bean(i));
-      }
-      return source;
-   }
-
-   private int deleteFromDump( Dump<Bean> source, int deleteModulo ) {
-      int deletions = 0;
-      for ( Bean bean : source ) {
-         if ( bean._id % deleteModulo == 0 ) {
-            deletions++;
-            source.deleteLast();
-         }
-      }
-      return deletions;
-   }
-
-   private void testCleanupBroken( long seekPos, String brokendata, int deleteModulo ) {
-      Dump<Bean> source = null;
-      Dump<Bean> dest = null;
-      try {
-         source = createSourceDump();
-         File sourceFile = source.getDumpFile();
-
-         int deletions = 0;
-         if ( deleteModulo > 0 ) {
-            deletions = deleteFromDump(source, deleteModulo);
-         }
-
-         long sourceSizeAfterDeleting = source.getDumpSize();
-
-         DumpUtils.closeSilently(source);
-
-         // now let's break the dump!
-         RandomAccessFile raf = new RandomAccessFile(sourceFile, "rw");
-         raf.seek(seekPos);
-         raf.writeUTF(brokendata);
-         raf.close();
-
-         // re-open
-         source = new Dump<>(Bean.class, sourceFile);
-
-         dest = createDestDump();
-
-         DumpUtils.cleanup(source, dest);
-
-         long destSizeAfterCleanup = dest.getDumpSize();
-
-         Assert.assertTrue("Dump did not shrink after cleanup", destSizeAfterCleanup < sourceSizeAfterDeleting);
-
-         int n = 0;
-         for ( Bean bean : dest ) {
-            Assert.assertTrue("wrong bean data after cleanup: " + bean._id, bean._id >= 0 && bean._id < NUMBER_OF_INSTANCES);
-            n++;
-         }
-
-         Assert.assertTrue("Dump did not shrink after cleanup", n < NUMBER_OF_INSTANCES);
-         System.err.println(n);
-         Assert.assertTrue("Dump shrank too much cleanup", n + 10 + deletions > NUMBER_OF_INSTANCES);
-      }
-      catch ( Exception e ) {
-         e.printStackTrace();
-         Assert.fail("failed to cleanup: " + e.getMessage());
-      }
-      finally {
-         DumpUtils.closeSilently(source);
-         DumpUtils.closeSilently(dest);
-      }
    }
 }


### PR DESCRIPTION
This method is very fragile and breaks with the changes in 8b0ef55ed539eac942625d916b6cf3a0baf346b9 improving the exception message on failures.