### PR TITLE
TECH: Switch to 2.0-SNAPSHOT versioning scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 /target
 /dump/target/
+*.versionsBackup

--- a/dump/pom.xml
+++ b/dump/pom.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
+
    <artifactId>util-dump</artifactId>
    <name>mkr util dump</name>
 
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20230607.1</version>
+      <version>2.0-SNAPSHOT</version>
    </parent>
 
    <dependencies>

--- a/dumpsearch/pom.xml
+++ b/dumpsearch/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
-   <groupId>mkr</groupId>
+
    <artifactId>util-dumpsearch</artifactId>
    <name>mkr util dumpsearch</name>
 
    <parent>
       <groupId>mkr</groupId>
       <artifactId>dump-pom</artifactId>
-      <version>1.20230607.1</version>
+      <version>2.0-SNAPSHOT</version>
    </parent>
 
    <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
    <modelVersion>4.0.0</modelVersion>
+
    <groupId>mkr</groupId>
    <artifactId>dump-pom</artifactId>
    <name>mkr dump pom</name>
-   <version>1.20230607.1</version>
+   <version>2.0-SNAPSHOT</version>
    <packaging>pom</packaging>
 
    <modules>


### PR DESCRIPTION
`mvn versions:set -DnewVersion=2.0-${commitId}` can be used in the internal build pipeline then.