### PR TITLE
Dump: consider deletions essential, not meta; flush them first

### DIFF
--- a/dump/src/util/dump/Dump.java
+++ b/dump/src/util/dump/Dump.java
@@ -466,6 +466,11 @@ public class Dump<E> implements DumpInput<E> {
     * call {@link #flushMeta()} too. Indexes are also flushed.
     */
    public void flush() throws IOException {
+      if ( _deletionsOutput != null ) {
+         _deletionsOutput.flush();
+         _deletionsOutputChannel.force(false);
+      }
+
       _outputStream.flush();
       _outputStreamChannel.force(false);
       for ( DumpIndex<E> index : new ArrayList<>(_indexes) ) {
@@ -480,10 +485,6 @@ public class Dump<E> implements DumpInput<E> {
     * Indes metas are also flushed.
     */
    public void flushMeta() throws IOException {
-      if ( _deletionsOutput != null ) {
-         _deletionsOutput.flush();
-         _deletionsOutputChannel.force(false);
-      }
       writeMeta();
       for ( DumpIndex<E> index : new ArrayList<>(_indexes) ) {
          index.flushMeta();


### PR DESCRIPTION
In case of an unclean shutdown, this should avoid
- the DuplicateKeyException during UniqueIndex load, since that also relies on deleted positions to be accurate, and
- the DuplicateKeyException during UniqueIndex rebuild from dump, since a deleted entry may appear twice.

The worst case scenario after this change is that an entry goes missing, that is, if the update write did not complete. It does not render the entire Dump and UniqueIndex unusable, though.