### PR TITLE
Fix duplication of util.time into util.dump.time

### DIFF
--- a/dump/src/util/dump/Dump.java
+++ b/dump/src/util/dump/Dump.java
@@ -59,7 +59,7 @@ import util.dump.stream.AesCrypter;
 import util.dump.stream.Compression;
 import util.dump.stream.ObjectStreamProvider;
 import util.dump.stream.SingleTypeObjectStreamProvider;
-import util.dump.time.StopWatch;
+import util.time.StopWatch;
 
 
 /**

--- a/dump/src/util/dump/time/StopWatch.java
+++ b/dump/src/util/dump/time/StopWatch.java
@@ -1,5 +1,8 @@
 package util.dump.time;
 
+import java.util.concurrent.TimeUnit;
+
+
 /**
  * <h2>Usage example:</h2>
  *
@@ -26,24 +29,34 @@ public class StopWatch {
    private long    _start;
    private boolean _resetOnToString = false;
 
-
    public StopWatch() {
       reset();
    }
 
-   /** returns the current interval in milliseconds */
+   /**
+    * returns the current interval in milliseconds
+    */
    public long getInterval() {
-      return System.currentTimeMillis() - _start;
+      return (TimeUnit.NANOSECONDS.toMillis(getIntervalNanos()));
+   }
+
+   /**
+    * returns the current interval in nanoseconds
+    */
+   public long getIntervalNanos() {
+      return System.nanoTime() - _start;
    }
 
    /**
     * resets the start time to the current time
     */
    public void reset() {
-      _start = System.currentTimeMillis();
+      _start = System.nanoTime();
    }
 
-   /** resets the timer every time the toString() method is called.
+   /**
+    * resets the timer every time the toString() method is called.
+    *
     * @return returns this, to enable fluent usage
     */
    public StopWatch setResetOnToString( boolean resetOnToString ) {
@@ -53,9 +66,10 @@ public class StopWatch {
 
    @Override
    public String toString() {
-      long milliseconds = System.currentTimeMillis() - _start;
-      if ( _resetOnToString )
+      long nanos = System.nanoTime() - _start;
+      if ( _resetOnToString ) {
          reset();
-      return TimeUtils.toHumanReadableFormat(milliseconds);
+      }
+      return TimeUtils.toHumanReadableFormat(TimeUnit.NANOSECONDS.toMillis(nanos));
    }
 }

--- a/dump/src/util/time/StopWatch.java
+++ b/dump/src/util/time/StopWatch.java
@@ -1,4 +1,4 @@
-package util.dump.time;
+package util.time;
 
 import java.util.concurrent.TimeUnit;
 

--- a/dump/src/util/time/TimeUtils.java
+++ b/dump/src/util/time/TimeUtils.java
@@ -8,16 +8,142 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 
-class TimeUtils {
+public class TimeUtils {
 
    public static final long             SECOND_IN_MILLIS   = 1000L;
    public static final long             MINUTE_IN_MILLIS   = 60 * SECOND_IN_MILLIS;
    public static final long             HOUR_IN_MILLIS     = 60 * MINUTE_IN_MILLIS;
    public static final long             DAY_IN_MILLIS      = 24 * HOUR_IN_MILLIS;
+   public static final long             WEEKS_IN_MILLIS    = 7 * DAY_IN_MILLIS;
+   public static final long             MONTHS_IN_MILLIS   = 30 * DAY_IN_MILLIS;
+   public static final long             QUARTERS_IN_MILLIS = 91 * DAY_IN_MILLIS;
+   public static final long             YEARS_IN_MILLIS    = 365 * DAY_IN_MILLIS;
 
-   private static final DecimalFormatSymbols  symbols            = new DecimalFormatSymbols(Locale.ENGLISH);
-   private static final DecimalFormat         dual               = new DecimalFormat("00", symbols);
-   private static final DecimalFormat         sf                 = new DecimalFormat("00.0##", symbols);
+   private static DecimalFormatSymbols  symbols            = new DecimalFormatSymbols(Locale.ENGLISH);
+   private static DecimalFormat         dual               = new DecimalFormat("00", symbols);
+   private static DecimalFormat         sf                 = new DecimalFormat("00.0##", symbols);
+
+   private static ThreadLocal<Calendar> CALENDAR           = new ThreadLocal<Calendar>() {
+
+      @Override
+      protected Calendar initialValue() {
+         return Calendar.getInstance();
+      }
+   };
+
+
+   /**
+    * checks if a Date is older than the number of days
+    *
+    * Example:
+    * <pre>
+    * Date oneWeekAgo = …
+    * dateOlderThanDays(oneWeekAgo, 3)  → true
+    * dateOlderThanDays(oneWeekAgo, 8)  → false
+    * </pre>
+    */
+   public static boolean dateOlderThanDays( Date date, long days ) {
+      long now = System.currentTimeMillis();
+      if ( date.getTime() < now - days * DAY_IN_MILLIS ) {
+         return true;
+      } else {
+         return false;
+      }
+   }
+
+   public static int getCalendarFieldValue( Date date, int calendarField ) {
+      Calendar calendar = CALENDAR.get();
+      calendar.setTime(date);
+      return calendar.get(calendarField);
+   }
+
+   /**
+    * <p>Returns the date that is rounded to a daily basis<p>
+    *
+    * Example:<br/>
+    *   roundDateToFullDay for the Date "2009-04-22 17:43:13" would return "2009-04-22 00:00:00"
+    */
+   public static Date roundDateToFullDay( final Date originalDate ) {
+      Calendar calendar = CALENDAR.get();
+      calendar.setTime(roundDateToFullHour(originalDate));
+      calendar.set(Calendar.HOUR_OF_DAY, 0);
+      return calendar.getTime();
+   }
+
+   /**
+    * <p>Returns the date that is rounded to a daily basis<p>
+    *
+    * Example:<br/>
+    *   roundDateToFullDay for the Date "2009-04-22 17:43:13" would return "2009-04-22 17:00:00"
+    */
+   public static Date roundDateToFullHour( final Date originalDate ) {
+      Calendar calendar = CALENDAR.get();
+      calendar.setTime(originalDate);
+      calendar.set(Calendar.MINUTE, 0);
+      calendar.set(Calendar.SECOND, 0);
+      calendar.set(Calendar.MILLISECOND, 0);
+      return calendar.getTime();
+   }
+
+   /**
+    * <p>Returns the date that is rounded to a monthly basis<p>
+    *
+    * Example:<br/>
+    *   roundDateToFullMonth for the Date "2009-04-22 17:43:13" would return "2009-04-01 00:00:00"
+    */
+   public static Date roundDateToFullMonth( final Date originalDate ) {
+      Calendar calendar = CALENDAR.get();
+      calendar.setTime(roundDateToFullDay(originalDate));
+      calendar.set(Calendar.DAY_OF_MONTH, 1);
+      return calendar.getTime();
+   }
+
+   /**
+    * <p>Returns the date that is rounded to a weekly basis. Beginning of the week is <b>Monday</b>.<p>
+    *
+    * Example:<br/>
+    *   roundDateToFullWeek for the Date "2009-04-22 17:43:13" would return "2009-04-20 00:00:00"
+    */
+   public static Date roundDateToFullWeek( final Date originalDate ) {
+      Calendar calendar = CALENDAR.get();
+      calendar.setTime(roundDateToFullDay(originalDate));
+      calendar.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
+      return calendar.getTime();
+   }
+
+   /**
+    * <p>calls Thread.sleep but immediately returns on an {@link InterruptedException} though it makes sure the interrupted status is saved</p>
+    * see <a href="http://www.javaspecialists.eu/archive/Issue146.html">The Law of the Sabotaged Doorbell</a>
+    *
+    * <p><b>Note:</b> There's no guarantee of how long the thread will actually sleep.
+    * Tests even showed, that sleepQuietly(100) might sleep more than <b>300 ms</b> if there's some load on the system!</p>
+    *
+    * @param milliseconds   time to sleep in milliseconds
+    */
+   public static void sleepQuietly( long milliseconds ) {
+      try {
+         TimeUnit.MILLISECONDS.sleep(milliseconds);
+      }
+      /**
+       * <quote>
+       * Note that the interrupted status is set to false when an InterruptedException is caused
+       * or when the Thread.interrupt method is explicitly called.
+       * Thus, when we catch an InterruptedException, we need to remember that the thread is now not interrupted anymore!
+       * In order to have orderly shutdown of the thread, we should keep the thread set to "interrupted".
+       * </quote>
+       */
+      catch ( InterruptedException e ) {
+         Thread.currentThread().interrupt();
+      }
+   }
+
+   /**
+    * @see #sleepQuietly(long)
+    * @param seconds    time to sleep in seconds
+    */
+   public static void sleepQuietlySeconds( long seconds ) {
+      sleepQuietly(seconds * SECOND_IN_MILLIS);
+   }
 
    /**
     * writes an interval in a nice human readable format.
@@ -80,4 +206,10 @@ class TimeUtils {
       return sb.toString();
    }
 
+   /**
+    * @see #toHumanReadableFormat(long)
+    */
+   public static String toHumanReadableFormatNano( long nanoseconds ) {
+      return toHumanReadableFormat(TimeUnit.NANOSECONDS.toMillis(nanoseconds));
+   }
 }

--- a/dump/src/util/time/TimeUtils.java
+++ b/dump/src/util/time/TimeUtils.java
@@ -1,4 +1,4 @@
-package util.dump.time;
+package util.time;
 
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;

--- a/dump/test/util/dump/ThreadLocalBenchmark.java
+++ b/dump/test/util/dump/ThreadLocalBenchmark.java
@@ -1,6 +1,6 @@
 package util.dump;
 
-import util.dump.time.StopWatch;
+import util.time.StopWatch;
 
 
 public class ThreadLocalBenchmark {

--- a/dump/test/util/dump/externalization/ExternalizableBeanBenchmark.java
+++ b/dump/test/util/dump/externalization/ExternalizableBeanBenchmark.java
@@ -17,7 +17,7 @@ import util.dump.ExternalizableBeanTest.TestBean;
 import util.dump.ExternalizableBeanTest.TestBeanSimple;
 import util.dump.stream.SingleTypeObjectInputStream;
 import util.dump.stream.SingleTypeObjectOutputStream;
-import util.dump.time.StopWatch;
+import util.time.StopWatch;
 
 
 public class ExternalizableBeanBenchmark {

--- a/dump/test/util/dump/externalization/ExternalizationBenchmark.java
+++ b/dump/test/util/dump/externalization/ExternalizationBenchmark.java
@@ -9,7 +9,7 @@ import java.io.PrintStream;
 import util.dump.stream.JavaObjectStreamProvider;
 import util.dump.stream.SingleTypeObjectInputStream;
 import util.dump.stream.SingleTypeObjectOutputStream;
-import util.dump.time.StopWatch;
+import util.time.StopWatch;
 
 
 public class ExternalizationBenchmark {

--- a/dump/test/util/dump/stream/AesBenchmark.java
+++ b/dump/test/util/dump/stream/AesBenchmark.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import util.dump.Dump;
 import util.dump.DumpUtils;
 import util.dump.ExternalizableBean;
-import util.dump.time.StopWatch;
+import util.time.StopWatch;
 
 
 public class AesBenchmark {

--- a/dump/test/util/dump/stream/CompressionBenchmark.java
+++ b/dump/test/util/dump/stream/CompressionBenchmark.java
@@ -14,7 +14,7 @@ import java.util.List;
 import util.dump.Dump;
 import util.dump.DumpUtils;
 import util.dump.ExternalizableBean;
-import util.dump.time.StopWatch;
+import util.time.StopWatch;
 
 
 public class CompressionBenchmark {


### PR DESCRIPTION
TimeUtils and StopWatch were copied from util to dump, which sits lower in the dependency tree. Now we have two copies of the same classes. Attempt to fix the matter by first unifying the pacakge name, then removing the duplication out of util.