### PR TITLE
TECH: Dump: do not prune, rename, or delete when opening in read-only mode

### DIFF
--- a/dump/src/util/dump/Dump.java
+++ b/dump/src/util/dump/Dump.java
@@ -405,7 +405,9 @@ public class Dump<E> implements DumpInput<E> {
       if ( _updateRaf != null ) {
          _updateRaf.close();
       }
-      writeMeta();
+      if ( !isReadonly() ) {
+         writeMeta();
+      }
       if ( _metaRaf != null ) {
          _metaRaf.close();
          _metaRaf = null;
@@ -489,7 +491,7 @@ public class Dump<E> implements DumpInput<E> {
     */
    public void flushMeta() throws IOException {
       if ( isReadonly() ) {
-         return;
+         throw new AccessControlException("Flushing meta-data not allowed in read-only mode.");
       }
 
       writeMeta();
@@ -846,6 +848,10 @@ public class Dump<E> implements DumpInput<E> {
     * @return false if the dump was already locked
     */
    protected boolean acquireFileLock() {
+      if ( isReadonly() ) {
+         return false;
+      }
+
       synchronized ( this ) {
          try {
             if ( _dumpLock != null ) {
@@ -1068,7 +1074,7 @@ public class Dump<E> implements DumpInput<E> {
 
    void writeMeta() throws IOException {
       if ( isReadonly() ) {
-         return;
+         throw new AccessControlException("Writing meta-data not allowed in read-only mode.");
       }
 
       getMetaRAF().seek(0);

--- a/dump/src/util/dump/Dump.java
+++ b/dump/src/util/dump/Dump.java
@@ -265,36 +265,39 @@ public class Dump<E> implements DumpInput<E> {
       OPENED_DUMPS.add(this);
       _cacheSize = cacheSize;
       try {
-         checkVersion();
-
          if ( !isReadonly() && !_mode.contains(DumpAccessFlag.shared) ) {
             // the lock is released as soon as the RandomAccessFile is closed (stackoverflow.com/questions/421833)
             acquireFileLock();
          }
 
          readDeletions();
+         initMeta();
 
-         if ( shouldBePruned() ) {
-            StopWatch t = new StopWatch();
-            _log.info("need to prune {} deleted entries from {}", _deletedPositions.size(), _dumpFile);
-            prune();
-            _log.info("...pruned {} in {}", _dumpFile, t);
+         if ( !isReadonly() ) {
+            checkVersion();
+
+            if ( shouldBePruned() ) {
+               StopWatch t = new StopWatch();
+               _log.info("need to prune {} deleted entries from {}", _deletedPositions.size(), _dumpFile);
+               prune();
+               _log.info("...pruned {} in {}", _dumpFile, t);
+            }
+
+            FileOutputStream fileOutputStream = new FileOutputStream(_dumpFile, true);
+            BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(fileOutputStream, DumpWriter.DEFAULT_BUFFER_SIZE);
+            _outputStream = new PositionAwareOutputStream(bufferedOutputStream, _dumpFile.length());
+            _outputStreamChannel = fileOutputStream.getChannel();
+            _writer = new DumpWriter<>(_outputStream, 0, _streamProvider);
+            _updateRaf = new RandomAccessFile(_dumpFile, "rw");
+
+            writeDictionary();
+
+            _updateByteOutput = new ByteArrayOutputStream(1024);
+            _updateOut = _streamProvider.createObjectOutput(_updateByteOutput);
          }
 
-         FileOutputStream fileOutputStream = new FileOutputStream(_dumpFile, true);
-         BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(fileOutputStream, DumpWriter.DEFAULT_BUFFER_SIZE);
-         _outputStream = new PositionAwareOutputStream(bufferedOutputStream, _dumpFile.length());
-         _outputStreamChannel = fileOutputStream.getChannel();
-         _writer = new DumpWriter<>(_outputStream, 0, _streamProvider);
          _raf = new RandomAccessFile(_dumpFile, "r");
-         _updateRaf = new RandomAccessFile(_dumpFile, "rw");
          _reader = new DumpReader<>(_dumpFile, false, _streamProvider);
-
-         initMeta();
-         writeDictionary();
-
-         _updateByteOutput = new ByteArrayOutputStream(1024);
-         _updateOut = _streamProvider.createObjectOutput(_updateByteOutput);
       }
       catch ( Exception argh ) {
          try {
@@ -485,6 +488,10 @@ public class Dump<E> implements DumpInput<E> {
     * Indes metas are also flushed.
     */
    public void flushMeta() throws IOException {
+      if ( isReadonly() ) {
+         return;
+      }
+
       writeMeta();
       for ( DumpIndex<E> index : new ArrayList<>(_indexes) ) {
          index.flushMeta();
@@ -1060,6 +1067,10 @@ public class Dump<E> implements DumpInput<E> {
    }
 
    void writeMeta() throws IOException {
+      if ( isReadonly() ) {
+         return;
+      }
+
       getMetaRAF().seek(0);
       getMetaRAF().writeLong(_sequence);
 
@@ -1093,7 +1104,6 @@ public class Dump<E> implements DumpInput<E> {
    }
 
    private void checkVersion() throws IOException {
-      initMeta();
       int codeVersion = getVersionFromCode();
       int dumpVersion = getVersionFromDump();
       if ( dumpVersion != codeVersion ) {

--- a/dump/test/util/dump/DumpTest.java
+++ b/dump/test/util/dump/DumpTest.java
@@ -58,9 +58,20 @@ public class DumpTest {
       }
    }
 
-   @Test(expected = AccessControlException.class)
-   public void testAddWithoutAccessRight() throws Exception {
+   @Test(expected = RuntimeException.class)
+   public void testAddWithoutAccessRight_FileNotFoundDueToReadOnly() throws Exception {
       File dumpFile = new File("DumpTest.dmp");
+      try (Dump<Bean> dump = new Dump<>(Bean.class, dumpFile, DumpAccessFlag.read)) {
+         dump.add(new Bean(1));
+      }
+   }
+
+   @Test(expected = AccessControlException.class)
+   public void testAddWithoutAccessRight_FileExistsDueToPreviousWriteAccess() throws Exception {
+      File dumpFile = new File("DumpTest.dmp");
+      try (Dump<Bean> dump = new Dump<>(Bean.class, dumpFile, DumpAccessFlag.add)) {
+         // do nothing, just initialize the file
+      }
       try (Dump<Bean> dump = new Dump<>(Bean.class, dumpFile, DumpAccessFlag.read)) {
          dump.add(new Bean(1));
       }


### PR DESCRIPTION
This avoids all tampering with the dump itself and its metadata when opening in read-only mode.