### PR TITLE
Index compaction considerations

### DIFF
--- a/dump/src/util/dump/GroupIndex.java
+++ b/dump/src/util/dump/GroupIndex.java
@@ -15,6 +15,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import gnu.trove.impl.hash.THash;
 import gnu.trove.list.TLongList;
 import gnu.trove.list.array.TLongArrayList;
 import gnu.trove.map.TIntObjectMap;
@@ -655,13 +656,17 @@ public class GroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex<E> {
    }
 
    protected boolean isCompactLookupNeeded() {
+      final THash lookup;
+
       if ( _fieldIsInt ) {
-         return _lookupInt.size() > 1000 && _lookupInt.size() * 2.5 < _lookupInt._set.length;
+         lookup = _lookupInt;
       } else if ( _fieldIsLong ) {
-         return _lookupLong.size() > 1000 && _lookupLong.size() * 2.5 < _lookupLong._set.length;
+         lookup = _lookupLong;
       } else {
          return false;
       }
+
+      return lookup != null && lookup.size() > 1000 && lookup.size() * 2.24f < lookup.capacity();
    }
 
    protected void compactLookup() {

--- a/dump/src/util/dump/GroupIndex.java
+++ b/dump/src/util/dump/GroupIndex.java
@@ -23,7 +23,6 @@ import gnu.trove.map.TLongIntMap;
 import gnu.trove.map.TLongObjectMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.map.hash.TLongIntHashMap;
-import gnu.trove.map.hash.TLongLongHashMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import gnu.trove.procedure.TIntObjectProcedure;
 import gnu.trove.procedure.TLongObjectProcedure;
@@ -617,7 +616,7 @@ public class GroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex<E> {
    void delete( E o, long pos ) {
       boolean deleted = delete0(o, pos);
 
-      if ( deleted && isCompactLookupNeeded() ) {
+      if ( deleted && isLookupCompactionNeeded() ) {
          compactLookup();
       }
    }
@@ -655,7 +654,7 @@ public class GroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex<E> {
       return false;
    }
 
-   protected boolean isCompactLookupNeeded() {
+   protected boolean isLookupCompactionNeeded() {
       final THash lookup;
 
       if ( _fieldIsInt ) {

--- a/dump/src/util/dump/UniqueIndex.java
+++ b/dump/src/util/dump/UniqueIndex.java
@@ -338,7 +338,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
       }
    }
 
-   protected boolean isCompactLookupNeeded() {
+   protected boolean isLookupCompactionNeeded() {
       final THash lookup;
 
       if ( _fieldIsInt ) {
@@ -615,7 +615,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
    void delete( E o, long pos ) {
       boolean deleted = delete0(o, pos);
 
-      if ( deleted && isCompactLookupNeeded() ) {
+      if ( deleted && isLookupCompactionNeeded() ) {
          compactLookup();
       }
    }

--- a/dump/src/util/dump/UniqueIndex.java
+++ b/dump/src/util/dump/UniqueIndex.java
@@ -13,6 +13,7 @@ import java.security.AccessControlException;
 import java.util.Collection;
 
 import gnu.trove.TLongCollection;
+import gnu.trove.impl.hash.THash;
 import gnu.trove.iterator.TLongIterator;
 import gnu.trove.list.TLongList;
 import gnu.trove.list.array.TLongArrayList;
@@ -338,13 +339,17 @@ public class UniqueIndex<E> extends DumpIndex<E> {
    }
 
    protected boolean isCompactLookupNeeded() {
+      final THash lookup;
+
       if ( _fieldIsInt ) {
-         return _lookupInt.size() > 1000 && _lookupInt.size() * 2.5 < _lookupInt._set.length;
+         lookup = _lookupInt;
       } else if ( _fieldIsLong ) {
-         return _lookupLong.size() > 1000 && _lookupLong.size() * 2.5 < _lookupLong._set.length;
+         lookup = _lookupLong;
       } else {
-         return _lookupObject.size() > 1000 && _lookupObject.size() * 2.5 < _lookupObject._set.length;
+         lookup = _lookupObject;
       }
+
+      return lookup != null && lookup.size() > 1000 && lookup.size() * 2.24f < lookup.capacity();
    }
 
    @Override


### PR DESCRIPTION
We want to compact trove maps on excessive oversize, but check only during add. Probably some legacy trade-off, since delete and add are used in update. This leaves a gap in case we keep removing from a particular dump, but never add or update afterwards, retaining the oversize indefinitely.

This solves the method nesting issue and ensures that on-demand compactions happen post-delete. Also, the tolerated oversize is reduced from 25% to 12%, since Trove guarantees <11% wasted space for large hash tables.