### PR TITLE
TECH: StringDeduplicator: deduplicate only emptystring by default

### DIFF
--- a/dump/src/util/dump/ExternalizationHelper.java
+++ b/dump/src/util/dump/ExternalizationHelper.java
@@ -553,7 +553,7 @@ class ExternalizationHelper {
       if ( isNotNull ) {
          s = DumpUtils.readUTF(in);
       }
-      return StringDeduplicator.deduplicate(s);
+      return StringDeduplicator.deduplicateEmpty(s);
    }
 
    static String[] readStringArray( ObjectInput in ) throws IOException {


### PR DESCRIPTION
Everything else might be too small to outweigh the overhead, or not even that redundant to begin with. We should provide some other means to decide on a field to field basis when to deduplicate inside de-externalization.