### PR TITLE
allow on-the-fly migration of primitive vs. boxed fields

### DIFF
--- a/dump/src/util/dump/ExternalizableBean.java
+++ b/dump/src/util/dump/ExternalizableBean.java
@@ -228,6 +228,8 @@ public interface ExternalizableBean extends Externalizable {
             FieldType inputFt, configuredFt;
             FieldAccessor f = null;
             Class defaultType = null;
+            externalize annotation = null;
+
             if ( (fieldIndexes[j] & 0xff) == fieldIndex ) {
                final FieldType fft = configuredFt = inputFt = fieldTypes[j];
                f = fieldAccessors[j];
@@ -246,6 +248,7 @@ public interface ExternalizableBean extends Externalizable {
                   } else if ( fieldTypeId == FieldType.List._id && inputFt._id == FieldType.ListOfStrings._id ) {
                      inputFt = FieldType.List;
                   } else if ( isCompatible(FieldType.forId(fieldTypeId), fft) ) {
+                     annotation = config._annotations[j];
                      inputFt = FieldType.forId(fieldTypeId);
                   } else if ( Boolean.TRUE.equals(CLASS_CHANGED_INCOMPATIBLY.computeIfAbsent(getClass(), clazz -> {
                      LoggerFactory.getLogger(clazz).error("The field type of index " + fieldIndex + //
@@ -281,7 +284,7 @@ public interface ExternalizableBean extends Externalizable {
                if ( f != null ) {
                   switch ( configuredFt ) {
                   case pInt -> f.setInt(this, d);
-                  case Integer -> f.set(this, d);
+                  case Integer -> f.set(this, annotation.sparseBoxed() && d == annotation.pIntNullValue() ? null : d);
                   default -> throw new IllegalStateException();
                   }
                }
@@ -292,7 +295,7 @@ public interface ExternalizableBean extends Externalizable {
                if ( f != null ) {
                   switch ( configuredFt ) {
                   case pBoolean -> f.setBoolean(this, d);
-                  case Boolean -> f.set(this, d);
+                  case Boolean -> f.set(this, annotation.sparseBoxed() && d == annotation.pBooleanNullValue() ? null : d);
                   default -> throw new IllegalStateException();
                   }
                }
@@ -303,7 +306,7 @@ public interface ExternalizableBean extends Externalizable {
                if ( f != null ) {
                   switch ( configuredFt ) {
                   case pByte -> f.setByte(this, d);
-                  case Byte -> f.set(this, d);
+                  case Byte -> f.set(this, annotation.sparseBoxed() && d == annotation.pByteNullValue() ? null : d);
                   default -> throw new IllegalStateException();
                   }
                }
@@ -314,7 +317,7 @@ public interface ExternalizableBean extends Externalizable {
                if ( f != null ) {
                   switch ( configuredFt ) {
                   case pChar -> f.setChar(this, d);
-                  case Character -> f.set(this, d);
+                  case Character -> f.set(this, annotation.sparseBoxed() && d == annotation.pCharNullValue() ? null : d);
                   default -> throw new IllegalStateException();
                   }
                }
@@ -325,7 +328,7 @@ public interface ExternalizableBean extends Externalizable {
                if ( f != null ) {
                   switch ( configuredFt ) {
                   case pDouble -> f.setDouble(this, d);
-                  case Double -> f.set(this, d);
+                  case Double -> f.set(this, annotation.sparseBoxed() && d == annotation.pDoubleNullValue() ? null : d);
                   default -> throw new IllegalStateException();
                   }
                }
@@ -336,7 +339,7 @@ public interface ExternalizableBean extends Externalizable {
                if ( f != null ) {
                   switch ( configuredFt ) {
                   case pFloat -> f.setFloat(this, d);
-                  case Float -> f.set(this, d);
+                  case Float -> f.set(this, annotation.sparseBoxed() && d == annotation.pFloatNullValue() ? null : d);
                   default -> throw new IllegalStateException();
                   }
                }
@@ -347,7 +350,7 @@ public interface ExternalizableBean extends Externalizable {
                if ( f != null ) {
                   switch ( configuredFt ) {
                   case pLong -> f.setLong(this, d);
-                  case Long -> f.set(this, d);
+                  case Long -> f.set(this, annotation.sparseBoxed() && d == annotation.pLongNullValue() ? null : d);
                   default -> throw new IllegalStateException();
                   }
                }
@@ -358,7 +361,7 @@ public interface ExternalizableBean extends Externalizable {
                if ( f != null ) {
                   switch ( configuredFt ) {
                   case pShort -> f.setShort(this, d);
-                  case Short -> f.set(this, d);
+                  case Short -> f.set(this, annotation.sparseBoxed() && d == annotation.pShortNullValue() ? null : d);
                   default -> throw new IllegalStateException();
                   }
                }
@@ -400,7 +403,7 @@ public interface ExternalizableBean extends Externalizable {
                Integer d = readInteger(in);
                if ( f != null ) {
                   switch ( configuredFt ) {
-                  case pInt -> f.setInt(this, d == null ? config._annotations[j].pIntNullValue() : d);
+                  case pInt -> f.setInt(this, d == null ? annotation.pIntNullValue() : d);
                   case Integer -> f.set(this, d);
                   default -> throw new IllegalStateException();
                   }
@@ -412,7 +415,7 @@ public interface ExternalizableBean extends Externalizable {
                if ( f != null ) {
                   switch ( configuredFt ) {
                   case pBoolean -> //noinspection SimplifiableConditionalExpression
-                        f.setBoolean(this, d == null ? config._annotations[j].pBooleanNullValue() : false);
+                        f.setBoolean(this, d == null ? annotation.pBooleanNullValue() : false);
                   case Boolean -> f.set(this, d);
                   default -> throw new IllegalStateException();
                   }
@@ -423,7 +426,7 @@ public interface ExternalizableBean extends Externalizable {
                Byte d = readByte(in);
                if ( f != null ) {
                   switch ( configuredFt ) {
-                  case pByte -> f.setByte(this, d == null ? config._annotations[j].pByteNullValue() : d);
+                  case pByte -> f.setByte(this, d == null ? annotation.pByteNullValue() : d);
                   case Byte -> f.set(this, d);
                   default -> throw new IllegalStateException();
                   }
@@ -434,7 +437,7 @@ public interface ExternalizableBean extends Externalizable {
                Character d = readCharacter(in);
                if ( f != null ) {
                   switch ( configuredFt ) {
-                  case pChar -> f.setChar(this, d == null ? config._annotations[j].pCharNullValue() : d);
+                  case pChar -> f.setChar(this, d == null ? annotation.pCharNullValue() : d);
                   case Character -> f.set(this, d);
                   default -> throw new IllegalStateException();
                   }
@@ -445,7 +448,7 @@ public interface ExternalizableBean extends Externalizable {
                Double d = readDouble(in);
                if ( f != null ) {
                   switch ( configuredFt ) {
-                  case pDouble -> f.setDouble(this, d == null ? config._annotations[j].pDoubleNullValue() : d);
+                  case pDouble -> f.setDouble(this, d == null ? annotation.pDoubleNullValue() : d);
                   case Double -> f.set(this, d);
                   default -> throw new IllegalStateException();
                   }
@@ -456,7 +459,7 @@ public interface ExternalizableBean extends Externalizable {
                Float d = readFloat(in);
                if ( f != null ) {
                   switch ( configuredFt ) {
-                  case pFloat -> f.setFloat(this, d == null ? config._annotations[j].pFloatNullValue() : d);
+                  case pFloat -> f.setFloat(this, d == null ? annotation.pFloatNullValue() : d);
                   case Float -> f.set(this, d);
                   default -> throw new IllegalStateException();
                   }
@@ -467,7 +470,7 @@ public interface ExternalizableBean extends Externalizable {
                Long d = readLong(in);
                if ( f != null ) {
                   switch ( configuredFt ) {
-                  case pLong -> f.setLong(this, d == null ? config._annotations[j].pLongNullValue() : d);
+                  case pLong -> f.setLong(this, d == null ? annotation.pLongNullValue() : d);
                   case Long -> f.set(this, d);
                   default -> throw new IllegalStateException();
                   }
@@ -478,7 +481,7 @@ public interface ExternalizableBean extends Externalizable {
                Short d = readShort(in);
                if ( f != null ) {
                   switch ( configuredFt ) {
-                  case pShort -> f.setShort(this, d == null ? config._annotations[j].pShortNullValue() : d);
+                  case pShort -> f.setShort(this, d == null ? annotation.pShortNullValue() : d);
                   case Short -> f.set(this, d);
                   default -> throw new IllegalStateException();
                   }
@@ -1419,6 +1422,11 @@ public interface ExternalizableBean extends Externalizable {
        * The value for primitive fields being migrated from boxed values, in case the latter reads null from the input.
        */
       short pShortNullValue() default 0;
+
+      /**
+       * Defines whether boxed fields are set to null whenever primitive input matches the pTypeNullValue
+       */
+      boolean sparseBoxed() default true;
 
       /**
        * Aka index. Must be unique. Convention is to start from 1. To guarantee compatibility between revisions of a bean,

--- a/dump/src/util/dump/ExternalizationHelper.java
+++ b/dump/src/util/dump/ExternalizationHelper.java
@@ -272,7 +272,6 @@ class ExternalizationHelper {
       }
 
       return switch ( containerType ) {
-         default -> d;
          case UnmodifiableCollection -> Collections.unmodifiableCollection(d);
 
          case UnmodifiableList -> Collections.unmodifiableList((List)d);
@@ -280,6 +279,7 @@ class ExternalizationHelper {
 
          case ImmutableList -> List.copyOf(d);
          case ImmutableSet -> Set.copyOf(d);
+         default -> d;
       };
    }
 
@@ -1189,6 +1189,7 @@ class ExternalizationHelper {
 
       Class           _class;
       ClassLoader     _classLoader;
+      externalize[]   _annotations;
       FieldAccessor[] _fieldAccessors;
       byte[]          _fieldIndexes;
       FieldType[]     _fieldTypes;
@@ -1218,6 +1219,7 @@ class ExternalizationHelper {
 
          Collections.sort(fieldInfos);
 
+         _annotations = new externalize[fieldInfos.size()];
          _fieldAccessors = new FieldAccessor[fieldInfos.size()];
          _fieldIndexes = new byte[fieldInfos.size()];
          _fieldTypes = new FieldType[fieldInfos.size()];
@@ -1226,6 +1228,7 @@ class ExternalizationHelper {
          _defaultGenericTypes1 = new Class[fieldInfos.size()];
          for ( int i = 0, length = fieldInfos.size(); i < length; i++ ) {
             FieldInfo fi = fieldInfos.get(i);
+            _annotations[i] = fi._annotation;
             _fieldAccessors[i] = fi._fieldAccessor;
             _fieldIndexes[i] = fi._fieldIndex;
             _fieldTypes[i] = fi._fieldType;
@@ -1241,6 +1244,8 @@ class ExternalizationHelper {
 
       private void addFieldInfo( List<FieldInfo> fieldInfos, externalize annotation, FieldAccessor fieldAccessor, Class type, String fieldName ) {
          FieldInfo fi = new FieldInfo();
+         fi._annotation = annotation;
+
          fi._fieldAccessor = fieldAccessor;
 
          byte index = annotation.value();
@@ -1454,6 +1459,7 @@ class ExternalizationHelper {
 
    static class FieldInfo implements Comparable<FieldInfo> {
 
+      externalize   _annotation;
       FieldAccessor _fieldAccessor;
       FieldType     _fieldType;
       byte          _fieldIndex;

--- a/dump/test/util/dump/externalization/BaseExternalizableBeanRoundtripTest.java
+++ b/dump/test/util/dump/externalization/BaseExternalizableBeanRoundtripTest.java
@@ -28,8 +28,12 @@ public abstract class BaseExternalizableBeanRoundtripTest<Bean extends Externali
 
    @SuppressWarnings("unchecked")
    protected void whenBeanIsExternalizedAndRead() {
+      whenBeanIsExternalizedAndRead((Class<Bean>)_beanToWrite.getClass());
+   }
+
+   protected void whenBeanIsExternalizedAndRead( Class<? extends Bean> beanClass ) {
       byte[] bytes = SingleTypeObjectOutputStream.writeSingleInstance(_beanToWrite);
-      _beanThatWasRead = SingleTypeObjectInputStream.readSingleInstance((Class<Bean>)_beanToWrite.getClass(), bytes);
+      _beanThatWasRead = SingleTypeObjectInputStream.readSingleInstance(beanClass, bytes);
    }
 
 }

--- a/dump/test/util/dump/externalization/BoxedPrimitiveMigrationTest.java
+++ b/dump/test/util/dump/externalization/BoxedPrimitiveMigrationTest.java
@@ -37,9 +37,16 @@ public class BoxedPrimitiveMigrationTest extends BaseExternalizableBeanRoundtrip
       assertThat(_beanThatWasRead).extracting("value").isEqualTo(11L);
    }
 
+   @Test
+   public void longPrimitiveToSparseBoxed() {
+      givenBean(new PrimitiveLong(13L));
+      whenBeanIsExternalizedAndRead(BoxedLong.class);
+      assertThat(_beanThatWasRead).extracting("value").isNull();
+   }
+
    public static final class BoxedLong implements ExternalizableBean {
 
-      @externalize(1)
+      @externalize(value = 1, pLongNullValue = 13L)
       Long value;
 
       public BoxedLong() {}

--- a/dump/test/util/dump/externalization/BoxedPrimitiveMigrationTest.java
+++ b/dump/test/util/dump/externalization/BoxedPrimitiveMigrationTest.java
@@ -1,0 +1,74 @@
+package util.dump.externalization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import util.dump.ExternalizableBean;
+
+
+public class BoxedPrimitiveMigrationTest extends BaseExternalizableBeanRoundtripTest<ExternalizableBean> {
+
+   @Test
+   public void longBoxedToPrimitive() {
+      givenBean(new BoxedLong(7L));
+      whenBeanIsExternalizedAndRead(PrimitiveLong.class);
+      assertThat(_beanThatWasRead).extracting("value").isEqualTo(7L);
+   }
+
+   @Test
+   public void longBoxedToPrimitiveDefault() {
+      givenBean(new BoxedLong(null));
+      whenBeanIsExternalizedAndRead(PrimitiveLongWithDefault.class);
+      assertThat(_beanThatWasRead).extracting("value").isEqualTo(Long.MIN_VALUE);
+   }
+
+   @Test
+   public void longBoxedToPrimitiveNull() {
+      givenBean(new BoxedLong(null));
+      whenBeanIsExternalizedAndRead(PrimitiveLong.class);
+      assertThat(_beanThatWasRead).extracting("value").isEqualTo(0L);
+   }
+
+   @Test
+   public void longPrimitiveToBoxed() {
+      givenBean(new PrimitiveLong(11L));
+      whenBeanIsExternalizedAndRead(BoxedLong.class);
+      assertThat(_beanThatWasRead).extracting("value").isEqualTo(11L);
+   }
+
+   public static final class BoxedLong implements ExternalizableBean {
+
+      @externalize(1)
+      Long value;
+
+      public BoxedLong() {}
+
+      public BoxedLong( Long value ) {
+         this.value = value;
+      }
+   }
+
+
+   public static final class PrimitiveLong implements ExternalizableBean {
+
+      @externalize(1)
+      long value;
+
+      public PrimitiveLong() {}
+
+      public PrimitiveLong( long value ) {
+         this.value = value;
+      }
+   }
+
+
+   public static final class PrimitiveLongWithDefault implements ExternalizableBean {
+
+      @externalize(value = 1, pLongNullValue = Long.MIN_VALUE)
+      long value;
+
+      public PrimitiveLongWithDefault() {}
+   }
+
+}


### PR DESCRIPTION
Establishes wire compatibility of boxed and primitive types of the same content, obsoleting the need for declaring a new field and bridging with wrappers. The @externalize annotation has been enhanced to provide fine-grained control, defaulting to established practice.

The pLongNullValue attributes et.al. define the primitive value to be equivalent to null, which is implicitly applied to the field whenever null is read from the input.
The sparseBoxed attribute defines whether this conversion is to be mirrored when converting from primitive to boxed values, i.e. null is applied to the field whenever the corresponding value is encountered.

All null-equivalent values default to zero / false, while sparse boxing is enabled by default.