### PR TITLE
Dumpindex: fix #getAllKeys() consistency

### DIFF
--- a/dump/src/util/dump/GroupIndex.java
+++ b/dump/src/util/dump/GroupIndex.java
@@ -180,7 +180,7 @@ public class GroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex<E> {
          for ( Positions positions : c ) {
             numPos += positions.size();
          }
-         TLongList pos = new TLongArrayList(numPos);
+         TLongList pos = new TLongArrayList(numPos, -1L);
          for ( Positions p : c ) {
             ensureSorting(p);
             for ( int i = 0, length = p.size(); i < length; i++ ) {

--- a/dump/src/util/dump/GroupIndex.java
+++ b/dump/src/util/dump/GroupIndex.java
@@ -174,31 +174,39 @@ public class GroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex<E> {
 
    @Override
    public TLongList getAllPositions() {
-      TLongList pos = new TLongArrayList(100000);
-      Collection<Positions> c = _fieldIsInt ? _lookupInt.valueCollection() : (_fieldIsLong ? _lookupLong.valueCollection() : _lookupObject.values());
-      for ( Positions p : c ) {
-         ensureSorting(p);
-         for ( int i = 0, length = p.size(); i < length; i++ ) {
-            long pp = p.get(i);
-            if ( !_dump._deletedPositions.contains(pp) ) {
-               pos.add(pp);
+      synchronized ( _dump ) {
+         Collection<Positions> c = _fieldIsInt ? _lookupInt.valueCollection() : (_fieldIsLong ? _lookupLong.valueCollection() : _lookupObject.values());
+         int numPos = 0;
+         for ( Positions positions : c ) {
+            numPos += positions.size();
+         }
+         TLongList pos = new TLongArrayList(numPos);
+         for ( Positions p : c ) {
+            ensureSorting(p);
+            for ( int i = 0, length = p.size(); i < length; i++ ) {
+               long pp = p.get(i);
+               if ( !_dump._deletedPositions.contains(pp) ) {
+                  pos.add(pp);
+               }
             }
          }
+         pos.sort();
+         return pos;
       }
-      pos.sort();
-      return pos;
    }
 
    @Override
    public int getNumKeys() {
-      if ( _lookupObject != null ) {
-         return _lookupObject.size();
-      }
-      if ( _lookupLong != null ) {
-         return _lookupLong.size();
-      }
-      if ( _lookupInt != null ) {
-         return _lookupInt.size();
+      synchronized ( _dump ) {
+         if ( _lookupObject != null ) {
+            return _lookupObject.size();
+         }
+         if ( _lookupLong != null ) {
+            return _lookupLong.size();
+         }
+         if ( _lookupInt != null ) {
+            return _lookupInt.size();
+         }
       }
       throw new IllegalStateException("weird, all lookup maps are null");
    }

--- a/dump/src/util/dump/InfiniteGroupIndex.java
+++ b/dump/src/util/dump/InfiniteGroupIndex.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static gnu.trove.impl.Constants.DEFAULT_CAPACITY;
 import gnu.trove.iterator.TLongIterator;
 import gnu.trove.list.TLongList;
 import gnu.trove.list.array.TLongArrayList;
@@ -177,7 +178,7 @@ public class InfiniteGroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex
    @Override
    public TLongList getAllPositions() {
       synchronized ( _dump ) {
-         TLongList pos = new TLongArrayList((int)(_lookupFileLength / (8 + (_fieldIsLong ? 8 : 4))));
+         TLongList pos = new TLongArrayList((int)(_lookupFileLength / (8 + (_fieldIsLong ? 8 : 4))), -1L);
 
          if ( _fieldIsInt || _fieldIsLong ) {
             DataInputStream in = null;
@@ -337,7 +338,7 @@ public class InfiniteGroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex
     */
    public Iterable<E> rangeLookup( long lowerKey, long upperKey ) {
       synchronized ( _dump ) {
-         TLongList pos = new TLongArrayList();
+         TLongList pos = new TLongArrayList(DEFAULT_CAPACITY, -1L);
          _overflowIndex._lookupLong.forEachEntry(( key, positions ) -> {
             if ( key >= lowerKey && key < upperKey )
                pos.addAll(positions);
@@ -395,7 +396,8 @@ public class InfiniteGroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex
             return cachedPositions;
          }
 
-         TLongList pos = new TLongArrayList(_overflowIndex.getPositions(key));
+         TLongList pos = new TLongArrayList(DEFAULT_CAPACITY, -1L);
+         pos.add(_overflowIndex.getPositions(key));
 
          int keyLength = 4 + 8; // in bytes
 
@@ -430,7 +432,8 @@ public class InfiniteGroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex
             return cachedPositions;
          }
 
-         TLongList pos = new TLongArrayList(_overflowIndex.getPositions(key));
+         TLongList pos = new TLongArrayList(DEFAULT_CAPACITY, -1L);
+         pos.add(_overflowIndex.getPositions(key));
 
          int keyLength = 8 + 8; // in bytes
 
@@ -477,7 +480,8 @@ public class InfiniteGroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex
 
          TLongList keyPositions = getObjectKeyPositions(key);
 
-         TLongList positions = new TLongArrayList(_overflowIndex.getPositions(key));
+         TLongList positions = new TLongArrayList(DEFAULT_CAPACITY, -1L);
+         positions.add(_overflowIndex.getPositions(key));
          for ( TLongIterator iterator = keyPositions.iterator(); iterator.hasNext(); ) {
             long pos = iterator.next();
             if ( _fieldIsExternalizable ) {
@@ -916,7 +920,7 @@ public class InfiniteGroupIndex<E> extends DumpIndex<E>implements NonUniqueIndex
    }
 
    private TLongList getObjectKeyPositions( Object key ) {
-      TLongList keyPositions = new TLongArrayList();
+      TLongList keyPositions = new TLongArrayList(DEFAULT_CAPACITY, -1L);
       int keyLength = 4 + 8; // in bytes
 
       int keyHashCode = key.hashCode();

--- a/dump/src/util/dump/UniqueIndex.java
+++ b/dump/src/util/dump/UniqueIndex.java
@@ -153,15 +153,21 @@ public class UniqueIndex<E> extends DumpIndex<E> {
    }
 
    public int[] getAllIntKeys() {
-      return _lookupInt.keys();
+      synchronized ( _dump ) {
+         return _lookupInt.keys();
+      }
    }
 
    public long[] getAllLongKeys() {
-      return _lookupLong.keys();
+      synchronized ( _dump ) {
+         return _lookupLong.keys();
+      }
    }
 
    public Object[] getAllObjectKeys() {
-      return _lookupObject.keys();
+      synchronized ( _dump ) {
+         return _lookupObject.keys();
+      }
    }
 
    @Override

--- a/dump/src/util/dump/UniqueIndex.java
+++ b/dump/src/util/dump/UniqueIndex.java
@@ -174,7 +174,7 @@ public class UniqueIndex<E> extends DumpIndex<E> {
    public TLongList getAllPositions() {
       synchronized ( _dump ) {
          TLongCollection c = _fieldIsInt ? _lookupInt.valueCollection() : (_fieldIsLong ? _lookupLong.valueCollection() : _lookupObject.valueCollection());
-         TLongList pos = new TLongArrayList(c.size(), 10000);
+         TLongList pos = new TLongArrayList(c.size(), -1L);
          for ( TLongIterator iterator = c.iterator(); iterator.hasNext(); ) {
             long p = iterator.next();
             if ( !_dump._deletedPositions.contains(p) ) {


### PR DESCRIPTION
This should primarily fix issues when a modification of a TLongLongHashMap occurs while iteration is in progress within #keys(). The most obvious issue is an out-of-bounds array access due to removal; other possible corruptions might be more subtle.

Furthermore, extractions of positions from DumpIndex implementations have apparently always been problematic, insofar as 0L is a perfectly valid position in any dump, though until now the TLongLists used in the retrieval have never been initialized with a non-zero no_entry_value. Except for UniqueIndex, where the no_entry_value had been initialized to a rather arbitrary 10_000L; if this position was ever the actual start of an externalized value inside the dump, we must have missed it consistently in the list of extracted positions.